### PR TITLE
feat: シグナル表示の時刻フォーマットを改善

### DIFF
--- a/src/app/(protected)/dashboard/_components/SignalsList.tsx
+++ b/src/app/(protected)/dashboard/_components/SignalsList.tsx
@@ -160,6 +160,8 @@ export function SignalsList({ signals, hasError }: SignalsListProps) {
                 {new Date(signal.evaluated_at).toLocaleTimeString("ja-JP", {
                   hour: "2-digit",
                   minute: "2-digit",
+                  hour12: false,
+                  timeZone: "Asia/Tokyo",
                 })}
               </p>
             </article>


### PR DESCRIPTION
- 24時間表記に変更（hour12: false）
- タイムゾーンをAsia/Tokyoに明示的に指定