### PR TITLE
Feat/front/dashboard 24h forecast

### DIFF
--- a/src/app/(protected)/dashboard/_components/TodayArea.tsx
+++ b/src/app/(protected)/dashboard/_components/TodayArea.tsx
@@ -3,15 +3,22 @@ import { TimeBasedHeader } from "./TimeBasedHeader";
 import { BeforeInputContent } from "./BeforeInputContent";
 import { AfterInputContent } from "./AfterInputContent";
 import { ForecastTableAutoScroll } from "./ForecastTable";
-import { getTodayDailyLog, getSuggestions, getTodaySignals } from "../actions";
+import {
+  getTodayDailyLog,
+  getSuggestions,
+  getTodaySignals,
+  getForecastSeries,
+} from "../actions";
 
 export async function TodayArea() {
   // すべてのデータを並列で取得（Fetch-then-Render）
-  const [todayDailyLog, suggestions, allSignals] = await Promise.all([
-    getTodayDailyLog(),
-    getSuggestions(),
-    getTodaySignals(), // カテゴリー指定なしで全件取得
-  ]);
+  const [todayDailyLog, suggestions, allSignals, forecastSeries] =
+    await Promise.all([
+      getTodayDailyLog(),
+      getSuggestions(),
+      getTodaySignals(), // カテゴリー指定なしで全件取得
+      getForecastSeries(),
+    ]);
 
   const normalizedSuggestions = Array.isArray(suggestions) ? suggestions : [];
   const hasDailyLog = todayDailyLog !== null;
@@ -25,7 +32,7 @@ export async function TodayArea() {
     <Card>
       <TimeBasedHeader hasDailyLog={hasDailyLog} />
       <CardContent className="space-y-6">
-        <ForecastTableAutoScroll />
+        <ForecastTableAutoScroll forecast={forecastSeries ?? null} />
         {!todayDailyLog ? (
           <BeforeInputContent envSignals={envSignals} />
         ) : (

--- a/src/app/(protected)/onboarding/welcome/_components/hooks/useOnboardingWizard.ts
+++ b/src/app/(protected)/onboarding/welcome/_components/hooks/useOnboardingWizard.ts
@@ -38,37 +38,44 @@ export function useOnboardingWizard({
       stepCompletion.prefecture &&
       currentStepIndex === totalSteps - 1
     ) {
+      // オンボーディング完了後はダッシュボードへリダイレクト
       router.push("/dashboard");
     }
   }, [stepCompletion, currentStepIndex, router, totalSteps]);
 
-  const handleStepComplete = useCallback((key: StepKey) => {
-    setStepCompletion((prev) => ({
-      ...prev,
-      [key]: true,
-    }));
+  const handleStepComplete = useCallback(
+    (key: StepKey) => {
+      setStepCompletion((prev) => ({
+        ...prev,
+        [key]: true,
+      }));
 
-    setCurrentStepIndex((prev) => {
-      if (prev < totalSteps - 1) {
-        return prev + 1;
-      }
-      return prev;
-    });
-  }, [totalSteps]);
+      setCurrentStepIndex((prev) => {
+        if (prev < totalSteps - 1) {
+          return prev + 1;
+        }
+        return prev;
+      });
+    },
+    [totalSteps]
+  );
 
-  const handleStepSkip = useCallback((key: StepKey) => {
-    setStepCompletion((prev) => ({
-      ...prev,
-      [key]: true,
-    }));
+  const handleStepSkip = useCallback(
+    (key: StepKey) => {
+      setStepCompletion((prev) => ({
+        ...prev,
+        [key]: true,
+      }));
 
-    setCurrentStepIndex((prev) => {
-      if (prev < totalSteps - 1) {
-        return prev + 1;
-      }
-      return prev;
-    });
-  }, [totalSteps]);
+      setCurrentStepIndex((prev) => {
+        if (prev < totalSteps - 1) {
+          return prev + 1;
+        }
+        return prev;
+      });
+    },
+    [totalSteps]
+  );
 
   const handleGoBack = useCallback(() => {
     setCurrentStepIndex((prev) => Math.max(0, prev - 1));
@@ -84,5 +91,3 @@ export function useOnboardingWizard({
     handleGoBack,
   };
 }
-
-


### PR DESCRIPTION
## 概要
ダッシュボードの「今日」エリア（TodayArea）に、24時間分の横スクロール予報テーブルを追加します。気圧・天気の変化を時系列で把握できるようにするためのUIと、バックエンドAPIとの連携を実装しています。

## 変更内容

### 追加・変更
- **ForecastTable** (`dashboard/_components/ForecastTable.tsx`)
  - 表示専用コンポーネント: 時刻・天気・気温・気圧の行、横スクロール、現在時刻列のハイライト
  - `ForecastTableAutoScroll`: 現在時刻の取得とスクロール制御を担当するラッパー
- **TodayArea** (`dashboard/_components/TodayArea.tsx`)
  - CardContent 先頭に `ForecastTableAutoScroll` を組み込み
  - `getForecastSeries()` で `/api/v1/forecast` を呼び出し、取得データを渡す
- **Server Action** (`dashboard/actions.ts`)
  - 型 `ForecastPoint` と `getForecastSeries()` を追加（10分キャッシュ、認証・都道府県未設定時は null 返却）
- **Hydration 対策**
  - 現在時刻はクライアントの `useEffect` で決定、SSR 時は `null` で hydration mismatch を回避
  - 表示用の時刻はインデックスベース（0〜23）で統一
- **その他**
  - オンボーディング用フック（`useOnboardingWizard`）の整理

### コミット
- feat: TodayArea に 24時間予報テーブルを追加し UI を調整
- feat: ダッシュボード予報連携とオンボーディングフックの整理