### PR TITLE
docs: triggers 設定ページの記述を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ npm run dev
 ### 設定
 
 - `/profile` - プロフィール編集
-- `/settings/triggers` - トリガー設定（登録・削除）
 
 ### その他
 


### PR DESCRIPTION
# 概要

DB リファクタリング（未使用テーブル削除・FK 化）に伴うドキュメントの更新。

# 目的

バックエンドで triggers / user_triggers テーブルが削除され、`/settings/triggers` ページは存在しないため、README の該当記述を削除する。

# 変更内容

- README.md の「設定」セクションから `/settings/triggers` の記述を削除

# 影響範囲

- ドキュメントのみ。コード・機能への影響なし
