### PR TITLE
feat: 関心ワード登録UIの見直し

### DIFF
--- a/src/app/(protected)/concern-topics/_components/ConcernTopicCheckboxList.tsx
+++ b/src/app/(protected)/concern-topics/_components/ConcernTopicCheckboxList.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { cn } from "@/lib/utils";
+import type { ConcernTopic } from "@/lib/schemas/concern-topics";
+
+export interface ConcernTopicCheckboxListProps {
+  topics: ConcernTopic[];
+  selectedKeys: Set<string>;
+  onToggle: (key: string, checked: boolean) => void;
+  disabled?: boolean;
+  /** オンボーディング用のコンパクト表示 */
+  compact?: boolean;
+  /** 選択数を表示する（例: 3件選択中） */
+  showSelectionCount?: boolean;
+  /** スクロール可能な高さ（max-height）。オンボーディング等で使用 */
+  maxHeight?: string;
+}
+
+export function ConcernTopicCheckboxList({
+  topics,
+  selectedKeys,
+  onToggle,
+  disabled = false,
+  compact = false,
+  showSelectionCount = false,
+  maxHeight,
+}: ConcernTopicCheckboxListProps) {
+  const listContent = (
+    <div className="space-y-2">
+      {topics.map((topic) => {
+        const isSelected = selectedKeys.has(topic.key);
+        return (
+          <label
+            key={topic.key}
+            className={cn(
+              "flex items-start gap-4 p-4 rounded-lg border cursor-pointer transition-all min-h-[52px] sm:min-h-[56px]",
+              "hover:bg-muted/50 active:bg-muted/70",
+              "touch-manipulation",
+              isSelected
+                ? "border-primary bg-primary/5 dark:bg-primary/10"
+                : "border-border hover:border-muted-foreground/30",
+              compact && "p-3 min-h-[48px] gap-3",
+            )}
+          >
+            <Checkbox
+              checked={isSelected}
+              onCheckedChange={(checked) =>
+                onToggle(topic.key, checked === true)
+              }
+              disabled={disabled}
+              className="mt-0.5 shrink-0"
+            />
+            <div className="flex-1 min-w-0 space-y-0.5">
+              <p
+                className={cn(
+                  "font-medium text-foreground",
+                  compact ? "text-sm" : "text-base",
+                )}
+              >
+                {topic.label_ja}
+              </p>
+              {topic.description_ja && (
+                <p
+                  className={cn(
+                    "text-muted-foreground leading-relaxed",
+                    compact ? "text-xs" : "text-sm",
+                  )}
+                >
+                  {topic.description_ja}
+                </p>
+              )}
+            </div>
+          </label>
+        );
+      })}
+    </div>
+  );
+
+  return (
+    <div className="space-y-3">
+      {showSelectionCount && (
+        <p className="text-sm text-muted-foreground">
+          {selectedKeys.size}件選択中
+        </p>
+      )}
+      <div
+        className={cn(maxHeight && "overflow-y-auto")}
+        style={maxHeight ? { maxHeight } : undefined}
+      >
+        {listContent}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(protected)/concern-topics/_components/ConcernTopicsForm.tsx
+++ b/src/app/(protected)/concern-topics/_components/ConcernTopicsForm.tsx
@@ -10,7 +10,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
 import type { ConcernTopic } from "@/lib/schemas/concern-topics";
 import {
@@ -18,6 +17,7 @@ import {
   getUserConcernTopicsAction,
   updateUserConcernTopicsAction,
 } from "../actions";
+import { ConcernTopicCheckboxList } from "./ConcernTopicCheckboxList";
 
 export function ConcernTopicsForm() {
   const [topics, setTopics] = useState<ConcernTopic[]>([]);
@@ -117,31 +117,13 @@ export function ConcernTopicsForm() {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="space-y-3">
-          {topics.map((topic) => (
-            <label
-              key={topic.key}
-              className="flex items-start gap-3 p-4 rounded-lg border hover:bg-muted/50 cursor-pointer transition-colors"
-            >
-              <Checkbox
-                checked={selectedKeys.has(topic.key)}
-                onCheckedChange={(checked) =>
-                  handleToggle(topic.key, checked === true)
-                }
-              />
-              <div className="flex-1 min-w-0">
-                <p className="font-medium text-gray-900 dark:text-gray-100">
-                  {topic.label_ja}
-                </p>
-                {topic.description_ja && (
-                  <p className="text-sm text-muted-foreground mt-0.5">
-                    {topic.description_ja}
-                  </p>
-                )}
-              </div>
-            </label>
-          ))}
-        </div>
+        <ConcernTopicCheckboxList
+          topics={topics}
+          selectedKeys={selectedKeys}
+          onToggle={handleToggle}
+          disabled={saving}
+          showSelectionCount
+        />
 
         <div className="flex justify-end pt-4">
           <Button onClick={handleSave} disabled={saving}>

--- a/src/app/(protected)/onboarding/welcome/_components/onboarding-steps.config.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/onboarding-steps.config.tsx
@@ -15,15 +15,15 @@ export type StepDefinition = {
 export const STEP_DEFINITIONS: StepDefinition[] = [
   {
     key: "prefecture",
-    title: "シグナルで体調の変化を知る",
+    title: "地域に合わせた提案を受け取る",
     description:
-      "地域の気象データをもとに、あなたの体調に影響するシグナルを検出します。",
+      "地域の気象データをもとに、あなたの体調に合った提案をお届けします。",
     required: true,
     icon: Thermometer,
     tutorial: (
       <div className="space-y-3 text-sm text-muted-foreground">
         <p>
-          気圧や温度の変化など、地域ごとの環境シグナルを取得するために、
+          気圧や温度の変化など、地域ごとの環境データをもとに提案を受け取るために、
           まずは「取得地域（都道府県）」を設定します。
         </p>
         <ul className="list-disc list-inside space-y-1 ml-2">

--- a/src/app/(protected)/onboarding/welcome/_components/steps/ConcernTopicsStep.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/steps/ConcernTopicsStep.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
+import { ConcernTopicCheckboxList } from "@/app/(protected)/concern-topics/_components/ConcernTopicCheckboxList";
 import type { ConcernTopic } from "@/lib/schemas/concern-topics";
 import {
   getConcernTopicsAction,
@@ -84,7 +84,7 @@ export function ConcernTopicsStep({
 
   if (loading) {
     return (
-      <div className="rounded-lg border p-6 flex items-center justify-center min-h-[200px]">
+      <div className="rounded-lg border border-border bg-card p-6 flex items-center justify-center min-h-[200px]">
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
       </div>
     );
@@ -92,7 +92,7 @@ export function ConcernTopicsStep({
 
   if (topics.length === 0) {
     return (
-      <div className="rounded-lg border p-6 space-y-4">
+      <div className="rounded-lg border border-border bg-card p-6 space-y-4">
         <p className="text-sm text-muted-foreground">
           登録できる関心ワードはありません
         </p>
@@ -104,32 +104,16 @@ export function ConcernTopicsStep({
   }
 
   return (
-    <div className="rounded-lg border p-6 space-y-4">
-      <div className="space-y-3 max-h-[300px] overflow-y-auto">
-        {topics.map((topic) => (
-          <label
-            key={topic.key}
-            className="flex items-start gap-3 p-3 rounded-lg border hover:bg-muted/50 cursor-pointer transition-colors"
-          >
-            <Checkbox
-              checked={selectedKeys.has(topic.key)}
-              onCheckedChange={(checked) =>
-                handleToggle(topic.key, checked === true)
-              }
-            />
-            <div className="flex-1 min-w-0">
-              <p className="font-medium text-gray-900 dark:text-gray-100 text-sm">
-                {topic.label_ja}
-              </p>
-              {topic.description_ja && (
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  {topic.description_ja}
-                </p>
-              )}
-            </div>
-          </label>
-        ))}
-      </div>
+    <div className="rounded-lg border border-border bg-card p-6 space-y-4">
+      <ConcernTopicCheckboxList
+        topics={topics}
+        selectedKeys={selectedKeys}
+        onToggle={handleToggle}
+        disabled={saving}
+        compact
+        showSelectionCount
+        maxHeight="300px"
+      />
 
       <Button
         className="w-full"


### PR DESCRIPTION
# 概要

関心ワード登録画面（`/concern-topics`）およびオンボーディングの関心ワードステップの UI を見直し、選びやすさ・分かりやすさ・操作感を向上させる。

# 目的

- 項目の見やすさ・選択状態の視認性を改善
- オンボーディングと専用ページの UI を一貫化
- オンボーディングの文言を「提案」に統一

# 変更内容

- ConcernTopicCheckboxList 共通コンポーネントを作成
- 選択数表示（〇件選択中）を追加
- 選択状態の視認性を改善（背景色・ボーダー）
- オンボーディングと専用ページで同一コンポーネントを使用
- オンボーディングの文言「シグナル」→「提案」に更新

# 影響範囲

- 関心ワードページ（`/concern-topics`）
- オンボーディングの関心ワードステップ（`/onboarding/welcome`）

# 関連ブランチ名

- back: `feat/back/concern-topics-ui-improvement`
