### PR TITLE
Refactor: Extract push notification browser API into usePushNotification hook

### DIFF
--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { Bell, BellOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,81 +9,17 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
-import {
-  requestNotificationPermission,
-  registerServiceWorker,
-  isSubscribed,
-  isNotificationSupported,
-  urlBase64ToUint8Array,
-} from "@/lib/push-notification";
-import {
-  subscribePushNotificationAction,
-  unsubscribePushNotificationAction,
-} from "@/app/(protected)/profile/actions";
-
-// VAPID public key
-const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY || "";
+import { usePushNotification } from "@/hooks/use-push-notification";
 
 export function NotificationSettings() {
-  const [subscribed, setSubscribed] = useState<boolean>(false);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [supported, setSupported] = useState<boolean>(true);
-
-  useEffect(() => {
-    // Check if notifications are supported
-    setSupported(isNotificationSupported());
-
-    // Check current subscription status
-    checkSubscriptionStatus();
-  }, []);
-
-  const checkSubscriptionStatus = async () => {
-    try {
-      const status = await isSubscribed();
-      setSubscribed(status);
-    } catch (error) {
-      console.error("Error checking subscription status:", error);
-    }
-  };
+  const { isSubscribed, isLoading, isSupported, subscribe, unsubscribe } =
+    usePushNotification();
 
   const handleSubscribe = async () => {
-    setLoading(true);
     try {
-      // Request notification permission
-      const permission = await requestNotificationPermission();
-      if (permission !== "granted") {
-        throw new Error("Notification permission denied");
-      }
-
-      // Register service worker
-      const registration = await registerServiceWorker();
-
-      // Check if already subscribed
-      let subscription = await registration.pushManager.getSubscription();
-
-      if (!subscription) {
-        // Subscribe to push notifications
-        const applicationServerKey = urlBase64ToUint8Array(VAPID_PUBLIC_KEY);
-        subscription = await registration.pushManager.subscribe({
-          userVisibleOnly: true,
-          applicationServerKey: applicationServerKey as BufferSource,
-        });
-      }
-
-      // Send subscription to backend via Server Action
-      const subscriptionJSON = subscription.toJSON();
-      const result = await subscribePushNotificationAction({
-        endpoint: subscriptionJSON.endpoint!,
-        p256dh_key: subscriptionJSON.keys!.p256dh,
-        auth_key: subscriptionJSON.keys!.auth,
-      });
-
-      if (result.status === "error") {
-        throw new Error(result.error.message);
-      }
-
-      setSubscribed(true);
+      await subscribe();
       toast.success("通知を有効にしました", {
         description:
           "朝8時は行動提案、夜20時は振り返りのリマインドが届きます",
@@ -107,50 +42,20 @@ export function NotificationSettings() {
       } else {
         toast.error("通知の設定に失敗しました");
       }
-    } finally {
-      setLoading(false);
     }
   };
 
   const handleUnsubscribe = async () => {
-    setLoading(true);
     try {
-      if (!("serviceWorker" in navigator)) {
-        throw new Error("Service workers are not supported");
-      }
-
-      const registration = await navigator.serviceWorker.ready;
-      const subscription = await registration.pushManager.getSubscription();
-
-      if (!subscription) {
-        console.log("No subscription found");
-        setSubscribed(false);
-        return;
-      }
-
-      // Unsubscribe from browser
-      await subscription.unsubscribe();
-
-      // Delete subscription from backend via Server Action
-      const result = await unsubscribePushNotificationAction(
-        subscription.endpoint,
-      );
-
-      if (result.status === "error") {
-        throw new Error(result.error.message);
-      }
-
-      setSubscribed(false);
+      await unsubscribe();
       toast.success("通知を無効にしました");
     } catch (error) {
       console.error("Unsubscribe error:", error);
       toast.error("通知の解除に失敗しました");
-    } finally {
-      setLoading(false);
     }
   };
 
-  if (!supported) {
+  if (!isSupported) {
     return (
       <Card>
         <CardHeader>
@@ -178,48 +83,60 @@ export function NotificationSettings() {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="space-y-1">
-            <p className="text-sm font-medium">
-              {subscribed ? "通知オン" : "通知オフ"}
-            </p>
-            <p className="text-sm text-muted-foreground">
-              {subscribed
-                ? "朝8時に今日の行動提案、夜20時に振り返りのリマインドが届きます"
-                : "通知を有効にすると朝8時と夜20時にリマインダーが届きます"}
-            </p>
+        {isLoading && !isSubscribed ? (
+          <div className="flex items-center justify-between">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+            <Skeleton className="h-9 w-28" />
           </div>
-          <Button
-            onClick={subscribed ? handleUnsubscribe : handleSubscribe}
-            disabled={loading}
-            variant={subscribed ? "outline" : "default"}
-          >
-            {loading ? (
-              "処理中..."
-            ) : subscribed ? (
-              <>
-                <BellOff className="mr-2 h-4 w-4" />
-                無効にする
-              </>
-            ) : (
-              <>
-                <Bell className="mr-2 h-4 w-4" />
-                有効にする
-              </>
-            )}
-          </Button>
-        </div>
+        ) : (
+          <>
+            <div className="flex items-center justify-between">
+              <div className="space-y-1">
+                <p className="text-sm font-medium">
+                  {isSubscribed ? "通知オン" : "通知オフ"}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {isSubscribed
+                    ? "朝8時に今日の行動提案、夜20時に振り返りのリマインドが届きます"
+                    : "通知を有効にすると朝8時と夜20時にリマインダーが届きます"}
+                </p>
+              </div>
+              <Button
+                onClick={isSubscribed ? handleUnsubscribe : handleSubscribe}
+                disabled={isLoading}
+                variant={isSubscribed ? "outline" : "default"}
+              >
+                {isLoading ? (
+                  "処理中..."
+                ) : isSubscribed ? (
+                  <>
+                    <BellOff className="mr-2 h-4 w-4" />
+                    無効にする
+                  </>
+                ) : (
+                  <>
+                    <Bell className="mr-2 h-4 w-4" />
+                    有効にする
+                  </>
+                )}
+              </Button>
+            </div>
 
-        {!subscribed && (
-          <div className="rounded-lg bg-muted p-4 text-sm">
-            <p className="font-medium mb-2">通知を有効にすると：</p>
-            <ul className="list-disc list-inside space-y-1 text-muted-foreground">
-              <li>朝8時：今日の行動提案</li>
-              <li>夜20時：1分で終わる振り返りフォームへのご案内</li>
-              <li>記録忘れを防ぐことができます</li>
-              <li>継続的な健康管理をサポートします</li>
-            </ul>
-          </div>
+            {!isSubscribed && (
+              <div className="rounded-lg bg-muted p-4 text-sm">
+                <p className="font-medium mb-2">通知を有効にすると：</p>
+                <ul className="list-disc list-inside space-y-1 text-muted-foreground">
+                  <li>朝8時：今日の行動提案</li>
+                  <li>夜20時：1分で終わる振り返りフォームへのご案内</li>
+                  <li>記録忘れを防ぐことができます</li>
+                  <li>継続的な健康管理をサポートします</li>
+                </ul>
+              </div>
+            )}
+          </>
         )}
       </CardContent>
     </Card>

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/hooks/use-push-notification.ts
+++ b/src/hooks/use-push-notification.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  requestNotificationPermission,
+  registerServiceWorker,
+  isSubscribed as checkIsSubscribed,
+  isNotificationSupported,
+  urlBase64ToUint8Array,
+} from "@/lib/push-notification";
+import {
+  subscribePushNotificationAction,
+  unsubscribePushNotificationAction,
+} from "@/app/(protected)/profile/actions";
+
+const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY || "";
+
+export function usePushNotification() {
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSupported, setIsSupported] = useState(true);
+
+  useEffect(() => {
+    setIsSupported(isNotificationSupported());
+
+    checkIsSubscribed()
+      .then(setIsSubscribed)
+      .catch(() => setIsSubscribed(false))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const subscribe = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const permission = await requestNotificationPermission();
+      if (permission !== "granted") {
+        throw new Error("Notification permission denied");
+      }
+
+      const registration = await registerServiceWorker();
+      let subscription = await registration.pushManager.getSubscription();
+
+      if (!subscription) {
+        const applicationServerKey = urlBase64ToUint8Array(VAPID_PUBLIC_KEY);
+        subscription = await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: applicationServerKey as BufferSource,
+        });
+      }
+
+      const subscriptionJSON = subscription.toJSON();
+      const result = await subscribePushNotificationAction({
+        endpoint: subscriptionJSON.endpoint!,
+        p256dh_key: subscriptionJSON.keys!.p256dh,
+        auth_key: subscriptionJSON.keys!.auth,
+      });
+
+      if (result.status === "error") {
+        throw new Error(result.error.message);
+      }
+
+      setIsSubscribed(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const unsubscribe = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      if (!("serviceWorker" in navigator)) {
+        throw new Error("Service workers are not supported");
+      }
+
+      const registration = await navigator.serviceWorker.ready;
+      const subscription = await registration.pushManager.getSubscription();
+
+      if (!subscription) {
+        setIsSubscribed(false);
+        return;
+      }
+
+      await subscription.unsubscribe();
+
+      const result = await unsubscribePushNotificationAction(
+        subscription.endpoint,
+      );
+
+      if (result.status === "error") {
+        throw new Error(result.error.message);
+      }
+
+      setIsSubscribed(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { isSubscribed, isLoading, isSupported, subscribe, unsubscribe };
+}

--- a/src/lib/push-notification.ts
+++ b/src/lib/push-notification.ts
@@ -7,7 +7,7 @@ export function urlBase64ToUint8Array(base64String: string): Uint8Array {
     .replace(/\-/g, "+")
     .replace(/_/g, "/");
 
-  const rawData = window.atob(base64);
+  const rawData = atob(base64);
   const outputArray = new Uint8Array(rawData.length);
 
   for (let i = 0; i < rawData.length; ++i) {


### PR DESCRIPTION
# 概要
NotificationSettingsコンポーネントに直接書かれていたブラウザAPI（Service Worker, Push Manager）の呼び出しを、カスタムフック`usePushNotification`に抽出するリファクタリング。

# 目的
- ブラウザAPIの副作用をカスタムフックに閉じ込め、コンポーネントのテスタビリティを向上させる
- 通知関連ロジックの再利用性を確保する
- UIコンポーネントを純粋な表示ロジックに近づける

# 変更内容
- `src/hooks/use-push-notification.ts` を新規作成し、購読状態管理・SW登録・Push購読の作成/解除・Server Action呼び出しのロジックを集約
- `src/components/NotificationSettings.tsx` をフック利用にリファクタリングし、UI表示のみに簡素化
- 購読状態確認中のSkeleton表示を追加（shadcn/ui Skeleton導入）
- `src/lib/push-notification.ts` の `urlBase64ToUint8Array` 内 `window.atob()` を `atob()` に変更しSSR安全性を改善

# 影響範囲
- プロフィール画面の通知設定UI（動作変更なし、内部リファクタリングのみ）

# 関連ブランチ名
なし

Closes #75