### PR TITLE
Refactor Container/Presentational pattern across pages

### DIFF
--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -7,26 +7,21 @@ import { Loading } from "@/components/ui/loading";
 import { redirect } from "next/navigation";
 import { getProfileAction } from "@/app/(protected)/profile/actions";
 
+async function requireOnboardingComplete() {
+  const profile = await getProfileAction();
+  const hasPrefecture = profile?.user?.prefecture_id != null;
+  if (!hasPrefecture) {
+    redirect("/onboarding/welcome");
+  }
+}
+
 export default async function DashboardPage() {
   const session = await auth();
   if (!session?.user?.id) {
     redirect("/signin?message=login_required");
   }
 
-  // 都道府県の設定状況をチェック
-  try {
-    const profile = await getProfileAction();
-    const hasPrefecture = profile?.user?.prefecture_id != null;
-
-    // 都道府県が未設定の場合、オンボーディングへリダイレクト
-    if (!hasPrefecture) {
-      redirect("/onboarding/welcome");
-    }
-  } catch (error) {
-    console.error("オンボーディングチェックエラー:", error);
-    // エラー時もオンボーディングへリダイレクト（安全側に倒す）
-    redirect("/onboarding/welcome");
-  }
+  await requireOnboardingComplete();
 
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-950">

--- a/src/app/(protected)/evening/loading.tsx
+++ b/src/app/(protected)/evening/loading.tsx
@@ -1,0 +1,57 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Loading } from "@/components/ui/loading";
+
+export default function EveningLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+      <div className="container mx-auto px-4 py-8">
+        <div className="max-w-2xl mx-auto">
+          {/* ヘッダー */}
+          <div className="text-center mb-8">
+            <div className="h-9 w-80 bg-slate-200 dark:bg-slate-700 rounded animate-pulse mx-auto mb-2" />
+            <div className="h-7 w-40 bg-slate-200 dark:bg-slate-700 rounded animate-pulse mx-auto" />
+          </div>
+
+          {/* 提案カードスケルトン */}
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <div className="h-6 w-32 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="h-20 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                <div className="h-20 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              </CardContent>
+            </Card>
+
+            {/* セルフスコアスケルトン */}
+            <Card>
+              <CardHeader>
+                <div className="h-6 w-48 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              </CardHeader>
+              <CardContent>
+                <div className="flex gap-2">
+                  <div className="flex-1 h-10 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                  <div className="flex-1 h-10 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                  <div className="flex-1 h-10 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* メモスケルトン */}
+            <Card>
+              <CardHeader>
+                <div className="h-6 w-20 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              </CardHeader>
+              <CardContent>
+                <div className="h-24 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              </CardContent>
+            </Card>
+
+            <Loading size="lg" text="データを読み込み中..." />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(protected)/evening/page.tsx
+++ b/src/app/(protected)/evening/page.tsx
@@ -1,9 +1,15 @@
 import { EveningReflectionForm } from "./_components/EveningReflectionForm";
+import { getTodaySuggestions, getTodayDailyLog } from "./actions";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
 
 export default async function EveningPage() {
   const today = new Date();
+
+  const [suggestions, dailyLog] = await Promise.all([
+    getTodaySuggestions(),
+    getTodayDailyLog(),
+  ]);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
@@ -18,7 +24,10 @@ export default async function EveningPage() {
           </div>
 
           {/* フォーム */}
-          <EveningReflectionForm />
+          <EveningReflectionForm
+            initialSuggestions={suggestions ?? []}
+            initialDailyLog={dailyLog}
+          />
         </div>
       </div>
     </div>

--- a/src/app/(protected)/morning/_components/MorningDeclarationForm.tsx
+++ b/src/app/(protected)/morning/_components/MorningDeclarationForm.tsx
@@ -13,6 +13,22 @@ import { Loader2, Bed, Heart, Zap } from "lucide-react";
 import { submitMorningDeclaration } from "@/app/(protected)/morning/actions";
 import { morningDeclarationSchema } from "@/lib/schemas/morning-declaration";
 
+const MOOD_OPTIONS = [
+  { value: 1, emoji: "😢", label: "とても悪い" },
+  { value: 2, emoji: "😕", label: "悪い" },
+  { value: 3, emoji: "😐", label: "普通" },
+  { value: 4, emoji: "🙂", label: "良い" },
+  { value: 5, emoji: "😊", label: "とても良い" },
+] as const;
+
+const FATIGUE_OPTIONS = [
+  { value: 1, label: "とても低い" },
+  { value: 2, label: "低い" },
+  { value: 3, label: "普通" },
+  { value: 4, label: "高い" },
+  { value: 5, label: "とても高い" },
+] as const;
+
 export function MorningDeclarationForm() {
   const [lastResult, action, pending] = useActionState(
     submitMorningDeclaration,
@@ -45,22 +61,6 @@ export function MorningDeclarationForm() {
       fatigue: "3",
     },
   });
-
-  const moodOptions = [
-    { value: 1, emoji: "😢", label: "とても悪い" },
-    { value: 2, emoji: "😕", label: "悪い" },
-    { value: 3, emoji: "😐", label: "普通" },
-    { value: 4, emoji: "🙂", label: "良い" },
-    { value: 5, emoji: "😊", label: "とても良い" },
-  ];
-
-  const fatigueOptions = [
-    { value: 1, label: "とても低い" },
-    { value: 2, label: "低い" },
-    { value: 3, label: "普通" },
-    { value: 4, label: "高い" },
-    { value: 5, label: "とても高い" },
-  ];
 
   return (
     <div className="space-y-4 w-full">
@@ -122,7 +122,7 @@ export function MorningDeclarationForm() {
             気分（1〜5）
           </Label>
           <div className="grid grid-cols-5 gap-2">
-            {moodOptions.map((option) => (
+            {MOOD_OPTIONS.map((option) => (
               <button
                 key={option.value}
                 type="button"
@@ -156,7 +156,7 @@ export function MorningDeclarationForm() {
             疲労感（1〜5）
           </Label>
           <div className="grid grid-cols-5 gap-2">
-            {fatigueOptions.map((option) => (
+            {FATIGUE_OPTIONS.map((option) => (
               <button
                 key={option.value}
                 type="button"

--- a/src/app/(protected)/morning/loading.tsx
+++ b/src/app/(protected)/morning/loading.tsx
@@ -1,0 +1,59 @@
+import { Loading } from "@/components/ui/loading";
+
+export default function MorningLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+      <div className="container mx-auto px-4 py-8">
+        <div className="max-w-2xl mx-auto">
+          {/* ヘッダー */}
+          <div className="text-center mb-8">
+            <div className="h-9 w-60 bg-slate-200 dark:bg-slate-700 rounded animate-pulse mx-auto mb-2" />
+            <div className="h-7 w-40 bg-slate-200 dark:bg-slate-700 rounded animate-pulse mx-auto" />
+          </div>
+
+          {/* フォームスケルトン */}
+          <div className="space-y-4 w-full">
+            {/* 睡眠時間 */}
+            <div className="space-y-2">
+              <div className="h-5 w-32 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              <div className="h-5 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+            </div>
+
+            {/* 気分 */}
+            <div className="space-y-2">
+              <div className="h-5 w-24 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              <div className="grid grid-cols-5 gap-2">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="h-20 bg-slate-200 dark:bg-slate-700 rounded-lg animate-pulse"
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* 疲労感 */}
+            <div className="space-y-2">
+              <div className="h-5 w-24 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              <div className="grid grid-cols-5 gap-2">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="h-20 bg-slate-200 dark:bg-slate-700 rounded-lg animate-pulse"
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* 送信ボタン */}
+            <div className="h-11 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+          </div>
+
+          <div className="mt-8">
+            <Loading size="lg" text="データを読み込み中..." />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(protected)/profile/_components/ProfileEditForm.tsx
+++ b/src/app/(protected)/profile/_components/ProfileEditForm.tsx
@@ -3,7 +3,7 @@
 import { useForm } from "@conform-to/react";
 import { parseWithZod } from "@conform-to/zod";
 import { useActionState } from "react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,7 +12,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Loader2, User, MapPin } from "lucide-react";
 import { profileSchema } from "@/lib/schemas/profile";
-import { updateProfileAction, getPrefectures } from "../actions";
+import { updateProfileAction } from "../actions";
 import {
   Select,
   SelectContent,
@@ -21,32 +21,25 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
+type Prefecture = {
+  id: number;
+  code: string;
+  name_ja: string;
+};
+
 interface ProfileEditFormProps {
   initialData: {
     name: string;
     prefecture_id?: number;
   };
+  prefectures: Prefecture[];
 }
 
-export function ProfileEditForm({ initialData }: ProfileEditFormProps) {
+export function ProfileEditForm({ initialData, prefectures }: ProfileEditFormProps) {
   const [lastResult, action, pending] = useActionState(
     updateProfileAction,
     undefined
   );
-  const [prefectures, setPrefectures] = useState<
-    Array<{ id: number; code: string; name_ja: string }>
-  >([]);
-
-  // 都道府県データを取得
-  useEffect(() => {
-    const fetchPrefectures = async () => {
-      const data = await getPrefectures();
-      if (data) {
-        setPrefectures(data);
-      }
-    };
-    fetchPrefectures();
-  }, []);
 
   // バックエンドエラーをtoastで表示
   useEffect(() => {

--- a/src/app/(protected)/profile/loading.tsx
+++ b/src/app/(protected)/profile/loading.tsx
@@ -1,0 +1,39 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Loading } from "@/components/ui/loading";
+
+export default function ProfileLoading() {
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="mb-8">
+          <div className="h-9 w-40 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+          <div className="h-5 w-56 bg-slate-200 dark:bg-slate-700 rounded animate-pulse mt-2" />
+        </div>
+
+        <div className="space-y-6">
+          {/* プロフィールフォームスケルトン */}
+          <Card className="w-full max-w-2xl mx-auto">
+            <CardContent className="space-y-6 pt-6">
+              {/* ニックネーム */}
+              <div className="space-y-2">
+                <div className="h-5 w-28 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                <div className="h-10 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              </div>
+              {/* 都道府県 */}
+              <div className="space-y-2">
+                <div className="h-5 w-20 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                <div className="h-10 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              </div>
+              {/* ボタン */}
+              <div className="flex justify-end">
+                <div className="h-10 w-24 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Loading size="lg" text="プロフィールを読み込み中..." />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -1,9 +1,12 @@
 import { ProfileEditForm } from "./_components/ProfileEditForm";
-import { getProfileAction } from "./actions";
+import { getProfileAction, getPrefectures } from "./actions";
 import { NotificationSettings } from "@/components/NotificationSettings";
 
 export default async function ProfilePage() {
-  const profile = await getProfileAction();
+  const [profile, prefectures] = await Promise.all([
+    getProfileAction(),
+    getPrefectures(),
+  ]);
 
   // デバッグ用
   console.log("Profile data:", profile);
@@ -27,6 +30,7 @@ export default async function ProfilePage() {
               name: profile?.user?.name || "",
               prefecture_id: profile?.user?.prefecture_id,
             }}
+            prefectures={prefectures ?? []}
           />
 
           <NotificationSettings />


### PR DESCRIPTION
# 概要
useEffect内でServer Actionを呼び出してデータ取得している箇所をServer Component（Container）に移動し、Container/Presentationalパターンを徹底するリファクタリング。

# 目的
- データ取得とUI描画の責務を明確に分離する
- useEffect内のServer Action呼び出しによるマウント時の不要なリクエストを排除する
- 競合状態のリスクを除去し、テスタビリティを向上させる
- コードベース全体のアーキテクチャパターンを統一する

# 変更内容
- EveningReflectionFormのデータ取得（getTodaySuggestions, getTodayDailyLog）をevening/page.tsxに移動し、propsで渡すように変更
- ProfileEditFormの都道府県データ取得（getPrefectures）をprofile/page.tsxに移動し、propsで渡すように変更
- MorningDeclarationFormの定数データ（moodOptions, fatigueOptions）をコンポーネント外のconst定数に移動
- dashboard/page.tsxのオンボーディング判定ロジックをrequireOnboardingComplete()ヘルパー関数に抽出
- evening/loading.tsx, profile/loading.tsx, morning/loading.tsxを新規作成（ページ固有のスケルトンUI）
- 既存テストをpropsベースのAPIに合わせて更新

# 影響範囲
- evening/page.tsx, EveningReflectionForm.tsx
- profile/page.tsx, ProfileEditForm.tsx
- morning/MorningDeclarationForm.tsx
- dashboard/page.tsx
- 新規: evening/loading.tsx, profile/loading.tsx, morning/loading.tsx

# 関連ブランチ名
なし（フロントエンドのみの変更）

Closes #77