### PR TITLE
Improve onboarding UI with welcome/completion screens and step visualization

### DIFF
--- a/src/app/(protected)/onboarding/welcome/_components/CompletionScreen.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/CompletionScreen.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { CheckCircle2, MapPin, Heart, Bell } from "lucide-react";
+
+type CompletionScreenProps = {
+  prefectureName: string | null;
+  concernTopicsCount: number;
+  notificationEnabled: boolean;
+  onGoToDashboard: () => void;
+};
+
+export function CompletionScreen({
+  prefectureName,
+  concernTopicsCount,
+  notificationEnabled,
+  onGoToDashboard,
+}: CompletionScreenProps) {
+  const summaryItems = [
+    {
+      icon: MapPin,
+      label: "取得地域",
+      value: prefectureName ?? "未設定",
+    },
+    {
+      icon: Heart,
+      label: "関心ワード",
+      value: `${concernTopicsCount}件登録`,
+    },
+    {
+      icon: Bell,
+      label: "通知",
+      value: notificationEnabled ? "有効" : "スキップ",
+    },
+  ];
+
+  return (
+    <Card className="shadow-xl border-primary/10">
+      <CardHeader className="text-center pb-2">
+        <div className="mx-auto w-16 h-16 rounded-full bg-green-500/10 flex items-center justify-center mb-4">
+          <CheckCircle2 className="h-8 w-8 text-green-500" />
+        </div>
+        <CardTitle className="text-2xl">設定が完了しました！</CardTitle>
+        <p className="text-muted-foreground mt-2">
+          Climodeがあなたに合った提案をお届けする準備ができました。
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
+          {summaryItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <div key={item.label} className="flex items-center gap-3">
+                <Icon className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm text-muted-foreground">
+                  {item.label}
+                </span>
+                <span className="text-sm font-medium ml-auto">
+                  {item.value}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+        <Button className="w-full" size="lg" onClick={onGoToDashboard}>
+          ダッシュボードへ
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(protected)/onboarding/welcome/_components/OnboardingWizard.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/OnboardingWizard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { CheckCircle2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -13,8 +15,11 @@ import { TutorialPanel } from "./TutorialPanel";
 import { PrefectureStep } from "./steps/PrefectureStep";
 import { ConcernTopicsStep } from "./steps/ConcernTopicsStep";
 import { NotificationStep } from "./steps/NotificationStep";
+import { WelcomeScreen } from "./WelcomeScreen";
+import { CompletionScreen } from "./CompletionScreen";
 import { STEP_DEFINITIONS } from "./onboarding-steps.config";
 import { useOnboardingWizard } from "./hooks/useOnboardingWizard";
+import type { ConcernTopic } from "@/lib/schemas/concern-topics";
 
 type PrefectureOption = {
   id: number;
@@ -25,38 +30,115 @@ type PrefectureOption = {
 type OnboardingWizardProps = {
   prefectures: PrefectureOption[];
   initialPrefectureId?: number | null;
+  concernTopics: ConcernTopic[];
+  initialSelectedKeys: string[];
 };
 
 export function OnboardingWizard({
   prefectures,
   initialPrefectureId,
+  concernTopics,
+  initialSelectedKeys,
 }: OnboardingWizardProps) {
   const {
+    phase,
     currentStepIndex,
     currentStep,
     totalSteps,
     progress,
-    handleGoBack,
+    stepCompletion,
+    skippedSteps,
+    handleStartOnboarding,
     handleStepComplete,
     handleStepSkip,
+    handleGoBack,
+    handleGoToStep,
+    handleGoToDashboard,
   } = useOnboardingWizard({
     initialPrefectureCompleted: Boolean(initialPrefectureId),
   });
 
+  const [selectedPrefectureId, setSelectedPrefectureId] = useState<
+    number | null
+  >(initialPrefectureId ?? null);
+  const [concernTopicsCount, setConcernTopicsCount] = useState(
+    initialSelectedKeys.length
+  );
+
+  // Step transition animation
+  const [displayedStepIndex, setDisplayedStepIndex] = useState(currentStepIndex);
+  const [animationClass, setAnimationClass] = useState("step-enter-active");
+
+  useEffect(() => {
+    if (currentStepIndex === displayedStepIndex) return;
+
+    const isForward = currentStepIndex > displayedStepIndex;
+    setAnimationClass(isForward ? "step-exit-to-left" : "step-exit-to-right");
+
+    const timeout = setTimeout(() => {
+      setDisplayedStepIndex(currentStepIndex);
+      setAnimationClass(
+        isForward ? "step-enter-from-right" : "step-enter-from-left"
+      );
+
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          setAnimationClass("step-enter-active");
+        });
+      });
+    }, 150);
+
+    return () => clearTimeout(timeout);
+  }, [currentStepIndex, displayedStepIndex]);
+
+  const displayedStep = STEP_DEFINITIONS[displayedStepIndex];
+
+  if (phase === "welcome") {
+    return <WelcomeScreen onStart={handleStartOnboarding} />;
+  }
+
+  if (phase === "complete") {
+    const prefectureName =
+      prefectures.find((p) => p.id === selectedPrefectureId)?.name_ja ?? null;
+    const notificationEnabled =
+      stepCompletion.notification && !skippedSteps.notification;
+
+    return (
+      <CompletionScreen
+        prefectureName={prefectureName}
+        concernTopicsCount={concernTopicsCount}
+        notificationEnabled={notificationEnabled}
+        onGoToDashboard={handleGoToDashboard}
+      />
+    );
+  }
+
   const formContent = (() => {
-    switch (currentStep.key) {
+    switch (displayedStep.key) {
       case "prefecture":
         return (
           <PrefectureStep
             prefectures={prefectures}
             initialPrefectureId={initialPrefectureId}
-            onComplete={() => handleStepComplete("prefecture")}
+            onComplete={(prefectureId?: number) => {
+              if (prefectureId) {
+                setSelectedPrefectureId(prefectureId);
+              }
+              handleStepComplete("prefecture");
+            }}
           />
         );
       case "concern_topics":
         return (
           <ConcernTopicsStep
-            onComplete={() => handleStepComplete("concern_topics")}
+            topics={concernTopics}
+            initialSelectedKeys={initialSelectedKeys}
+            onComplete={(count?: number) => {
+              if (count !== undefined) {
+                setConcernTopicsCount(count);
+              }
+              handleStepComplete("concern_topics");
+            }}
             onSkip={() => handleStepSkip("concern_topics")}
           />
         );
@@ -99,31 +181,63 @@ export function OnboardingWizard({
         </div>
       </CardHeader>
       <CardContent className="space-y-8">
-        <div className="grid gap-6 lg:grid-cols-2">
-          <TutorialPanel
-            icon={currentStep.icon}
-            title={currentStep.title}
-            content={currentStep.tutorial}
-          />
-          {formContent}
+        <div className={animationClass}>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <details className="lg:hidden group" open>
+              <summary className="flex items-center gap-2 text-sm font-medium cursor-pointer py-2 list-none [&::-webkit-details-marker]:hidden">
+                <displayedStep.icon className="h-4 w-4 text-primary" />
+                <span>ガイドを表示</span>
+                <span className="ml-auto text-muted-foreground text-xs group-open:rotate-180 transition-transform">
+                  ▼
+                </span>
+              </summary>
+              <TutorialPanel
+                icon={displayedStep.icon}
+                title={displayedStep.title}
+                subtitle={displayedStep.subtitle}
+                content={displayedStep.tutorial}
+              />
+            </details>
+            <div className="hidden lg:block">
+              <TutorialPanel
+                icon={displayedStep.icon}
+                title={displayedStep.title}
+                subtitle={displayedStep.subtitle}
+                content={displayedStep.tutorial}
+              />
+            </div>
+            {formContent}
+          </div>
         </div>
         <div className="flex items-center justify-between text-sm text-muted-foreground">
           <div className="flex gap-2">
             {STEP_DEFINITIONS.map((step, index) => {
               const Icon = step.icon;
               const active = index === currentStepIndex;
+              const completed = stepCompletion[step.key];
+              const clickable = completed && !active;
+
               return (
-                <div
+                <button
+                  type="button"
                   key={step.key}
-                  className={`flex items-center gap-2 px-3 py-2 rounded-full border text-xs ${
+                  onClick={() => clickable && handleGoToStep(index)}
+                  disabled={!clickable}
+                  className={`flex items-center gap-2 px-3 py-2 rounded-full border text-xs transition-colors ${
                     active
                       ? "border-primary bg-primary/10 text-primary"
-                      : "border-muted text-muted-foreground"
-                  }`}
+                      : completed
+                        ? "border-green-500 bg-green-500/10 text-green-700 dark:text-green-400 cursor-pointer hover:bg-green-500/20"
+                        : "border-muted text-muted-foreground"
+                  } ${!clickable && !active ? "cursor-default" : ""}`}
                 >
-                  <Icon className="h-4 w-4" />
-                  <span>{step.title}</span>
-                </div>
+                  {completed && !active ? (
+                    <CheckCircle2 className="h-4 w-4" />
+                  ) : (
+                    <Icon className="h-4 w-4" />
+                  )}
+                  <span className="hidden sm:inline">{step.title}</span>
+                </button>
               );
             })}
           </div>

--- a/src/app/(protected)/onboarding/welcome/_components/TutorialPanel.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/TutorialPanel.tsx
@@ -5,10 +5,16 @@ import type React from "react";
 type TutorialPanelProps = {
   icon: React.ElementType;
   title: string;
+  subtitle: string;
   content: React.ReactNode;
 };
 
-export function TutorialPanel({ icon: Icon, title, content }: TutorialPanelProps) {
+export function TutorialPanel({
+  icon: Icon,
+  title,
+  subtitle,
+  content,
+}: TutorialPanelProps) {
   return (
     <div className="rounded-lg border bg-muted/30 p-6 space-y-4">
       <div className="flex items-center gap-3">
@@ -17,14 +23,10 @@ export function TutorialPanel({ icon: Icon, title, content }: TutorialPanelProps
         </div>
         <div>
           <p className="text-lg font-semibold">{title}</p>
-          <p className="text-sm text-muted-foreground">
-            Climodeの体験の流れを確認しましょう
-          </p>
+          <p className="text-sm text-muted-foreground">{subtitle}</p>
         </div>
       </div>
       {content}
     </div>
   );
 }
-
-

--- a/src/app/(protected)/onboarding/welcome/_components/WelcomeScreen.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/WelcomeScreen.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Thermometer, Heart, Bell } from "lucide-react";
+
+type WelcomeScreenProps = {
+  onStart: () => void;
+};
+
+const features = [
+  {
+    icon: Thermometer,
+    title: "地域に合わせた提案",
+    description:
+      "気圧や気温の変化をもとに、あなたの体調に合ったアドバイスをお届けします。",
+  },
+  {
+    icon: Heart,
+    title: "あなたの関心に合わせて",
+    description:
+      "気になる体調・環境を選ぶと、よりパーソナライズされた提案を受け取れます。",
+  },
+  {
+    icon: Bell,
+    title: "やさしいリマインド",
+    description:
+      "朝は行動提案、夜は振り返り。無理のないリズムで習慣をサポートします。",
+  },
+];
+
+export function WelcomeScreen({ onStart }: WelcomeScreenProps) {
+  return (
+    <Card className="shadow-xl border-primary/10">
+      <CardHeader className="text-center pb-2">
+        <CardTitle className="text-3xl">ようこそClimodeへ</CardTitle>
+        <p className="text-muted-foreground mt-2">
+          あなたの体調と環境の関係を見つけ、毎日をもっと快適に過ごしましょう。
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-3">
+          {features.map((feature) => {
+            const Icon = feature.icon;
+            return (
+              <div
+                key={feature.title}
+                className="rounded-lg border bg-muted/30 p-4 text-center space-y-2"
+              >
+                <div className="mx-auto w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center">
+                  <Icon className="h-6 w-6 text-primary" />
+                </div>
+                <p className="font-semibold text-sm">{feature.title}</p>
+                <p className="text-xs text-muted-foreground">
+                  {feature.description}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+        <Button className="w-full" size="lg" onClick={onStart}>
+          はじめる
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(protected)/onboarding/welcome/_components/onboarding-steps.config.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/onboarding-steps.config.tsx
@@ -7,6 +7,7 @@ export type StepDefinition = {
   key: StepKey;
   title: string;
   description: string;
+  subtitle: string;
   required: boolean;
   tutorial: React.ReactNode;
   icon: React.ElementType;
@@ -18,6 +19,7 @@ export const STEP_DEFINITIONS: StepDefinition[] = [
     title: "地域に合わせた提案を受け取る",
     description:
       "地域の気象データをもとに、あなたの体調に合った提案をお届けします。",
+    subtitle: "ステップ1: あなたの地域を設定しましょう",
     required: true,
     icon: Thermometer,
     tutorial: (
@@ -41,6 +43,7 @@ export const STEP_DEFINITIONS: StepDefinition[] = [
     title: "関心ワードを登録する",
     description:
       "気になる体調・環境を選ぶと、よりあなたに合った提案をお届けします。",
+    subtitle: "ステップ2: 気になる項目を選びましょう",
     required: false,
     icon: Heart,
     tutorial: (
@@ -61,6 +64,7 @@ export const STEP_DEFINITIONS: StepDefinition[] = [
     key: "notification",
     title: "通知でリズムを整える",
     description: "朝と夜のやさしいリマインドで、振り返りを自然な習慣にします。",
+    subtitle: "ステップ3: 通知で習慣をサポートしましょう",
     required: false,
     icon: Bell,
     tutorial: (

--- a/src/app/(protected)/onboarding/welcome/_components/steps/ConcernTopicsStep.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/steps/ConcernTopicsStep.tsx
@@ -1,54 +1,31 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { ConcernTopicCheckboxList } from "@/app/(protected)/concern-topics/_components/ConcernTopicCheckboxList";
 import type { ConcernTopic } from "@/lib/schemas/concern-topics";
-import {
-  getConcernTopicsAction,
-  getUserConcernTopicsAction,
-  updateUserConcernTopicsAction,
-} from "@/app/(protected)/concern-topics/actions";
+import { updateUserConcernTopicsAction } from "@/app/(protected)/concern-topics/actions";
 
 type ConcernTopicsStepProps = {
-  onComplete: () => void;
+  topics: ConcernTopic[];
+  initialSelectedKeys: string[];
+  onComplete: (count?: number) => void;
   onSkip: () => void;
 };
 
 export function ConcernTopicsStep({
+  topics,
+  initialSelectedKeys,
   onComplete,
   onSkip,
 }: ConcernTopicsStepProps) {
-  const [topics, setTopics] = useState<ConcernTopic[]>([]);
-  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
-  const [loading, setLoading] = useState(true);
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(
+    new Set(initialSelectedKeys)
+  );
   const [saving, setSaving] = useState(false);
-
-  useEffect(() => {
-    const fetch = async () => {
-      setLoading(true);
-      try {
-        const [topicsData, userKeys] = await Promise.all([
-          getConcernTopicsAction(),
-          getUserConcernTopicsAction(),
-        ]);
-        if (topicsData) {
-          setTopics(topicsData);
-        }
-        if (userKeys) {
-          setSelectedKeys(new Set(userKeys));
-        }
-      } catch {
-        toast.error("関心ワードの取得に失敗しました");
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetch();
-  }, []);
 
   const handleToggle = (key: string, checked: boolean) => {
     setSelectedKeys((prev) => {
@@ -70,7 +47,7 @@ export function ConcernTopicsStep({
       );
       if (result.status === "success") {
         toast.success("関心ワードを登録しました");
-        onComplete();
+        onComplete(selectedKeys.size);
       } else {
         toast.error(result.error?.message ?? "登録に失敗しました");
       }
@@ -80,14 +57,6 @@ export function ConcernTopicsStep({
       setSaving(false);
     }
   };
-
-  if (loading) {
-    return (
-      <div className="rounded-lg border border-border bg-card p-6 flex items-center justify-center min-h-[200px]">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    );
-  }
 
   if (topics.length === 0) {
     return (

--- a/src/app/(protected)/onboarding/welcome/_components/steps/PrefectureStep.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/steps/PrefectureStep.tsx
@@ -25,7 +25,7 @@ type PrefectureOption = {
 type PrefectureStepProps = {
   prefectures: PrefectureOption[];
   initialPrefectureId?: number | null;
-  onComplete: () => void;
+  onComplete: (prefectureId?: number) => void;
 };
 
 export function PrefectureStep({
@@ -60,7 +60,7 @@ export function PrefectureStep({
           }
           toast.success("取得地域を保存しました");
         }
-        onComplete();
+        onComplete(Number(selectedPrefecture));
       } catch {
         setError("取得地域の保存に失敗しました");
       }

--- a/src/app/(protected)/onboarding/welcome/loading.tsx
+++ b/src/app/(protected)/onboarding/welcome/loading.tsx
@@ -1,0 +1,63 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export default function OnboardingLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+      <div className="container mx-auto max-w-4xl px-4 py-12">
+        <Card className="shadow-xl border-primary/10">
+          <CardHeader>
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div className="space-y-2">
+                <Skeleton className="h-7 w-56" />
+                <Skeleton className="h-5 w-80" />
+              </div>
+              <div className="w-full md:w-60">
+                <div className="flex justify-between mb-1">
+                  <Skeleton className="h-4 w-8" />
+                  <Skeleton className="h-4 w-20" />
+                </div>
+                <Skeleton className="h-2 w-full rounded-full" />
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-8">
+            <div className="grid gap-6 lg:grid-cols-2">
+              {/* TutorialPanel skeleton */}
+              <div className="rounded-lg border bg-muted/30 p-6 space-y-4">
+                <div className="flex items-center gap-3">
+                  <Skeleton className="w-10 h-10 rounded-full" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-5 w-40" />
+                    <Skeleton className="h-4 w-56" />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-full" />
+                  <Skeleton className="h-4 w-5/6" />
+                  <Skeleton className="h-4 w-4/6" />
+                </div>
+              </div>
+              {/* Form panel skeleton */}
+              <div className="rounded-lg border p-6 space-y-4">
+                <Skeleton className="h-5 w-32" />
+                <Skeleton className="h-10 w-full rounded" />
+                <Skeleton className="h-4 w-48" />
+                <Skeleton className="h-10 w-full rounded" />
+              </div>
+            </div>
+            {/* Step badges skeleton */}
+            <div className="flex items-center justify-between">
+              <div className="flex gap-2">
+                {[0, 1, 2].map((i) => (
+                  <Skeleton key={i} className="h-9 w-28 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-9 w-32 rounded" />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(protected)/onboarding/welcome/page.tsx
+++ b/src/app/(protected)/onboarding/welcome/page.tsx
@@ -6,6 +6,11 @@ import {
   getProfileAction,
   getPrefectures,
 } from "@/app/(protected)/profile/actions";
+import {
+  getConcernTopicsAction,
+  getUserConcernTopicsAction,
+} from "@/app/(protected)/concern-topics/actions";
+import type { ConcernTopic } from "@/lib/schemas/concern-topics";
 import { OnboardingWizard } from "./_components/OnboardingWizard";
 
 type PrefectureOption = {
@@ -31,12 +36,27 @@ export default async function OnboardingWelcomePage() {
   }
   const initialPrefectureId = profile?.user?.prefecture_id ?? null;
 
+  let concernTopics: ConcernTopic[] = [];
+  let initialSelectedKeys: string[] = [];
+  try {
+    const [topicsData, userKeys] = await Promise.all([
+      getConcernTopicsAction(),
+      getUserConcernTopicsAction(),
+    ]);
+    concernTopics = topicsData ?? [];
+    initialSelectedKeys = userKeys ?? [];
+  } catch {
+    // 関心ワードの取得失敗時は空配列のまま進める
+  }
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       <div className="container mx-auto max-w-4xl px-4 py-12">
         <OnboardingWizard
           prefectures={prefectures}
           initialPrefectureId={initialPrefectureId}
+          concernTopics={concernTopics}
+          initialSelectedKeys={initialSelectedKeys}
         />
       </div>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -120,3 +120,29 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .step-enter-from-right {
+    opacity: 0;
+    transform: translateX(30px);
+  }
+  .step-enter-from-left {
+    opacity: 0;
+    transform: translateX(-30px);
+  }
+  .step-enter-active {
+    opacity: 1;
+    transform: translateX(0);
+    transition: opacity 200ms ease-out, transform 200ms ease-out;
+  }
+  .step-exit-to-left {
+    opacity: 0;
+    transform: translateX(-30px);
+    transition: opacity 150ms ease-in, transform 150ms ease-in;
+  }
+  .step-exit-to-right {
+    opacity: 0;
+    transform: translateX(30px);
+    transition: opacity 150ms ease-in, transform 150ms ease-in;
+  }
+}


### PR DESCRIPTION
# 概要
オンボーディングUIを総合的に改善し、新規ユーザーの初期設定体験を向上させる。

# 目的
- 新規ユーザーがアプリの価値を理解し、迷いなく初期設定を完了できるようにする
- ステップの進捗・完了状態を視覚的に明確にする
- ページ遷移時のローディング状態を適切に表示する

# 変更内容
- ウェルカム画面（ステップ0）を追加。3つの特徴カードでアプリを紹介。都道府県設定済みユーザーはスキップ
- 完了画面を追加。設定サマリー（地域・関心ワード件数・通知状態）を表示し「ダッシュボードへ」ボタンで遷移
- ステップバッジに完了チェックマーク表示、完了済みステップへのクリックナビゲーション対応
- プログレスバーを位置ベースから完了ステップ数ベースに変更
- ConcernTopicsStepのデータ取得をuseEffectからServer Component（page.tsx）に移行（Container/Presentationalパターン）
- loading.tsxを新規作成（Skeletonベースのローディング表示）
- ステップ切り替え時のスライドアニメーション（CSS transitionのみ）
- TutorialPanelのサブタイトルをステップごとに個別化
- モバイル: ステップバッジをアイコンのみ表示、TutorialPanelを折りたたみ式に

# 影響範囲
- `(protected)/onboarding/welcome/` 配下のコンポーネント全体
- `globals.css`（アニメーションユーティリティ追加）

# 関連ブランチ名
なし（フロントエンドのみ）