### PR TITLE
Improve about page with service overview, features, and mechanism sections

### DIFF
--- a/src/app/(auth)/about/_data/evidence-sources.ts
+++ b/src/app/(auth)/about/_data/evidence-sources.ts
@@ -6,7 +6,6 @@
 export interface EvidenceSource {
   name: string;
   description?: string;
-  url?: string;
 }
 
 export interface EvidenceCategory {
@@ -30,7 +29,6 @@ export const EVIDENCE_CATEGORIES: EvidenceCategory[] = [
       {
         name: "天気痛ドクター（監修：愛知医科大学 佐藤純医師）",
         description: "気象病・天気痛に関する予報傾向と基礎知識",
-        url: "https://tenki-tsura.com/",
       },
     ],
   },
@@ -42,7 +40,6 @@ export const EVIDENCE_CATEGORIES: EvidenceCategory[] = [
       {
         name: "環境省「熱中症予防情報サイト」",
         description: "暑さ指数(WBGT)の定義および判定基準",
-        url: "https://www.wbgt.env.go.jp/",
       },
       {
         name: "鹿児島大学 法医学分野（林敬人教授ら）の研究",
@@ -59,12 +56,10 @@ export const EVIDENCE_CATEGORIES: EvidenceCategory[] = [
       {
         name: "厚生労働省",
         description: "インフルエンザQ&A（湿度の保持について）",
-        url: "https://www.mhlw.go.jp/bunya/kenkou/kekkaku-kansenshou01/qa.html",
       },
       {
         name: "東京都健康安全研究センター",
         description: "「健康で快適な居住環境のために」（ビル管理・居住環境）",
-        url: "https://www.tokyo-eiken.go.jp/",
       },
     ],
   },
@@ -77,7 +72,6 @@ export const EVIDENCE_CATEGORIES: EvidenceCategory[] = [
         name: "厚生労働省「健康づくりのための睡眠ガイド2023」",
         description:
           "概要：成人・高齢者・こどもごとの推奨睡眠時間および休養指針",
-        url: "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/kenkou_iryou/kenkou/suimin/index.html",
       },
     ],
   },

--- a/src/app/(auth)/about/page.tsx
+++ b/src/app/(auth)/about/page.tsx
@@ -1,30 +1,173 @@
 import type { Metadata } from "next";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { AlertTriangle, ExternalLink } from "lucide-react";
+import {
+  AlertTriangle,
+  Heart,
+  Zap,
+  Calendar,
+  TrendingUp,
+  CloudSun,
+  Bed,
+  Activity,
+  ArrowRight,
+} from "lucide-react";
 import Link from "next/link";
 import { EVIDENCE_CATEGORIES } from "./_data/evidence-sources";
 
 export const metadata: Metadata = {
-  title: "提案ロジックと参照エビデンス",
+  title: "Climodeについて",
   description:
-    "Climodeが体調提案に使用しているロジックと、参照している公的機関のデータ・学術研究・専門家の知見について説明します。",
+    "Climodeは天気・気圧などの環境データと睡眠・気分・疲労などの体調データを掛け合わせ、毎朝のシグナルと提案を届けるヘルスケアアプリです。",
 };
+
+const FEATURES = [
+  {
+    icon: Zap,
+    title: "今日の提案",
+    description:
+      "毎朝、気象条件とあなたの体調傾向から、その日に気をつけるべきポイントを提案します。",
+    color: "text-blue-600 dark:text-blue-400",
+    bg: "bg-blue-100 dark:bg-blue-900/30",
+  },
+  {
+    icon: Heart,
+    title: "体調トラッキング",
+    description:
+      "睡眠時間・気分・疲労度を毎日記録。シンプルな入力で継続しやすい設計です。",
+    color: "text-green-600 dark:text-green-400",
+    bg: "bg-green-100 dark:bg-green-900/30",
+  },
+  {
+    icon: Calendar,
+    title: "振り返り・レポート",
+    description:
+      "カレンダー形式で体調の推移を一覧し、週次レポートで傾向を把握できます。",
+    color: "text-purple-600 dark:text-purple-400",
+    bg: "bg-purple-100 dark:bg-purple-900/30",
+  },
+  {
+    icon: TrendingUp,
+    title: "相関分析",
+    description:
+      "環境データと体調データの相関を分析し、あなた固有のパターンを発見します。",
+    color: "text-orange-600 dark:text-orange-400",
+    bg: "bg-orange-100 dark:bg-orange-900/30",
+  },
+] as const;
 
 export default function AboutPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4 py-12">
-      <div className="w-full max-w-3xl mx-auto space-y-8">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-            提案ロジックと参照エビデンス
+      <div className="w-full max-w-3xl mx-auto space-y-12">
+        {/* サービス概要 */}
+        <section className="text-center space-y-4">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+            Climodeについて
           </h1>
-          <p className="mt-4 text-gray-600 dark:text-gray-400">
-            Climode
-            では、以下の公的機関のデータ、学術研究、専門家の知見を参考に、独自のアルゴリズムで解析・提案を行っています。
+          <p className="text-lg text-gray-600 dark:text-gray-400">
+            体調の「ゆらぎ」に、今日の提案を届ける
           </p>
-        </div>
+          <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
+            Climodeは、天気・気圧などの環境データと、睡眠・気分・疲労などの体調データを掛け合わせて分析し、毎朝あなたに合った提案を届けるヘルスケアアプリです。
+          </p>
+        </section>
 
+        {/* 主な機能 */}
+        <section className="space-y-6">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white text-center">
+            主な機能
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {FEATURES.map((feature) => (
+              <Card key={feature.title}>
+                <CardContent className="pt-6">
+                  <div className="flex items-start gap-4">
+                    <div className={`rounded-lg p-2 ${feature.bg}`}>
+                      <feature.icon className={`h-5 w-5 ${feature.color}`} />
+                    </div>
+                    <div className="space-y-1">
+                      <p className="font-medium text-gray-900 dark:text-white">
+                        {feature.title}
+                      </p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        {feature.description}
+                      </p>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        {/* 仕組み */}
+        <section className="space-y-6">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white text-center">
+            Climodeの仕組み
+          </h2>
+          <Card>
+            <CardContent className="pt-6 space-y-6">
+              <div className="flex flex-col sm:flex-row items-center gap-4 justify-center">
+                <div className="flex items-center gap-2 rounded-lg bg-blue-50 dark:bg-blue-900/20 px-4 py-3">
+                  <CloudSun className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                  <span className="text-sm font-medium text-gray-900 dark:text-white">
+                    環境データ
+                  </span>
+                </div>
+                <span className="text-gray-400 text-lg font-bold">×</span>
+                <div className="flex items-center gap-2 rounded-lg bg-green-50 dark:bg-green-900/20 px-4 py-3">
+                  <Activity className="h-5 w-5 text-green-600 dark:text-green-400" />
+                  <span className="text-sm font-medium text-gray-900 dark:text-white">
+                    体調データ
+                  </span>
+                </div>
+                <ArrowRight className="h-5 w-5 text-gray-400 hidden sm:block" />
+                <span className="text-gray-400 text-lg font-bold sm:hidden">
+                  ↓
+                </span>
+                <div className="flex items-center gap-2 rounded-lg bg-purple-50 dark:bg-purple-900/20 px-4 py-3">
+                  <Zap className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+                  <span className="text-sm font-medium text-gray-900 dark:text-white">
+                    シグナル・提案
+                  </span>
+                </div>
+              </div>
+              <div className="space-y-4 text-sm text-gray-600 dark:text-gray-400">
+                <div className="flex items-start gap-3">
+                  <CloudSun className="h-4 w-4 mt-0.5 shrink-0 text-blue-500" />
+                  <p>
+                    <span className="font-medium text-gray-900 dark:text-white">
+                      環境データ
+                    </span>
+                    ：気温・湿度・気圧・天候などをOpen-Meteo
+                    APIから自動取得し、気圧変化や暑さ指数を算出します。
+                  </p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Bed className="h-4 w-4 mt-0.5 shrink-0 text-green-500" />
+                  <p>
+                    <span className="font-medium text-gray-900 dark:text-white">
+                      体調データ
+                    </span>
+                    ：毎日記録する睡眠時間・気分・疲労度をもとに、あなたの体調傾向を把握します。
+                  </p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Zap className="h-4 w-4 mt-0.5 shrink-0 text-purple-500" />
+                  <p>
+                    <span className="font-medium text-gray-900 dark:text-white">
+                      シグナル・提案
+                    </span>
+                    ：環境と体調の組み合わせから、各種エビデンスを参考にしたルールエンジンがその日のリスクと対策を生成します。
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+
+        {/* 免責事項 */}
         <Alert className="border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-800 text-amber-900 dark:text-amber-100">
           <AlertTriangle className="h-4 w-4" />
           <AlertTitle>必ずお読みください</AlertTitle>
@@ -33,43 +176,41 @@ export default function AboutPage() {
           </AlertDescription>
         </Alert>
 
-        <div className="space-y-6">
-          {EVIDENCE_CATEGORIES.map((category) => (
-            <Card key={category.id}>
-              <CardHeader>
-                <CardTitle className="text-lg">{category.title}</CardTitle>
-                <p className="text-sm text-muted-foreground font-normal">
-                  {category.description}
-                </p>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {category.sources.map((source, idx) => (
-                  <div key={idx} className="space-y-1">
-                    <p className="font-medium text-gray-900 dark:text-white">
-                      {source.name}
-                    </p>
-                    {source.description && (
-                      <p className="text-sm text-gray-600 dark:text-gray-400">
-                        {source.description}
+        {/* エビデンス */}
+        <section className="space-y-6">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white text-center">
+            参照エビデンス
+          </h2>
+          <p className="text-center text-sm text-gray-600 dark:text-gray-400">
+            Climodeでは、以下の公的機関のデータ、学術研究、専門家の知見を参考に、独自のアルゴリズムで解析・提案を行っています。
+          </p>
+          <div className="space-y-6">
+            {EVIDENCE_CATEGORIES.map((category) => (
+              <Card key={category.id}>
+                <CardHeader>
+                  <CardTitle className="text-lg">{category.title}</CardTitle>
+                  <p className="text-sm text-muted-foreground font-normal">
+                    {category.description}
+                  </p>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {category.sources.map((source, idx) => (
+                    <div key={idx} className="space-y-1">
+                      <p className="font-medium text-gray-900 dark:text-white">
+                        {source.name}
                       </p>
-                    )}
-                    {source.url && (
-                      <Link
-                        href={source.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-                      >
-                        公式サイト
-                        <ExternalLink className="h-3 w-3" />
-                      </Link>
-                    )}
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+                      {source.description && (
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
+                          {source.description}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
 
         <div className="pt-4 text-center">
           <Link href="/" className="text-primary hover:underline text-sm">

--- a/src/app/(protected)/_components/DashboardMenu.tsx
+++ b/src/app/(protected)/_components/DashboardMenu.tsx
@@ -17,7 +17,6 @@ import {
   LogOut,
   Home,
   Heart,
-  Info,
   Settings,
 } from "lucide-react";
 import Link from "next/link";
@@ -79,17 +78,6 @@ const menuItemConfigs = [
     activeBg: "bg-rose-50 dark:bg-rose-950/30",
     activeBorder: "border-l-rose-500",
     hoverIconBg: "group-hover:bg-rose-200 dark:group-hover:bg-rose-800/60",
-  },
-  {
-    icon: Info,
-    label: "About",
-    href: "/about",
-    description: "提案ロジックと参照エビデンス",
-    iconBg: "bg-amber-100 dark:bg-amber-900/50",
-    iconColor: "text-amber-600 dark:text-amber-400",
-    activeBg: "bg-amber-50 dark:bg-amber-950/30",
-    activeBorder: "border-l-amber-500",
-    hoverIconBg: "group-hover:bg-amber-200 dark:group-hover:bg-amber-800/60",
   },
 ];
 


### PR DESCRIPTION
# 概要
aboutページにサービス概要・主な機能・仕組みセクションを追加し、ページ全体の構成を改善した。

# 目的
未ログインユーザーがサービスの全体像を理解できるようにする。既存のエビデンス情報・免責事項は維持しつつ、aboutページとして期待される情報を提供する。

# 変更内容
- サービス概要セクション（コンセプト・タグライン）を追加
- 主な機能セクション（今日の提案、体調トラッキング、振り返り・レポート、相関分析）を追加
- 仕組みセクション（環境データ × 体調データ → シグナル・提案のフロー図と説明）を追加
- エビデンスデータから外部URLを削除
- ダッシュボードメニューからAboutリンクを削除
- メタデータ（title/description）をaboutページとして適切な内容に更新

# 影響範囲
- `src/app/(auth)/about/page.tsx`
- `src/app/(auth)/about/_data/evidence-sources.ts`
- `src/app/(protected)/_components/DashboardMenu.tsx`

# 関連ブランチ名
なし（フロントエンドのみ）

Closes #101