### PR TITLE
Rename concern word to concern topic in Japanese labels

### DIFF
--- a/src/app/(protected)/_components/DashboardMenu.tsx
+++ b/src/app/(protected)/_components/DashboardMenu.tsx
@@ -70,7 +70,7 @@ const menuItemConfigs = [
   },
   {
     icon: Heart,
-    label: "関心ワード",
+    label: "関心トピック",
     href: "/concern-topics",
     description: "気になる体調・環境を登録",
     iconBg: "bg-rose-100 dark:bg-rose-900/50",

--- a/src/app/(protected)/concern-topics/_components/ConcernTopicsForm.tsx
+++ b/src/app/(protected)/concern-topics/_components/ConcernTopicsForm.tsx
@@ -40,7 +40,7 @@ export function ConcernTopicsForm() {
           setSelectedKeys(new Set(userKeys));
         }
       } catch {
-        toast.error("関心ワードの取得に失敗しました");
+        toast.error("関心トピックの取得に失敗しました");
       } finally {
         setLoading(false);
       }
@@ -67,12 +67,12 @@ export function ConcernTopicsForm() {
         Array.from(selectedKeys),
       );
       if (result.status === "success") {
-        toast.success("関心ワードを更新しました");
+        toast.success("関心トピックを更新しました");
       } else {
         toast.error(result.error?.message ?? "更新に失敗しました");
       }
     } catch {
-      toast.error("関心ワードの更新に失敗しました");
+      toast.error("関心トピックの更新に失敗しました");
     } finally {
       setSaving(false);
     }
@@ -94,10 +94,10 @@ export function ConcernTopicsForm() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Heart className="h-5 w-5" />
-            関心ワード
+            関心トピック
           </CardTitle>
           <CardDescription>
-            登録できる関心ワードはありません
+            登録できる関心トピックはありません
           </CardDescription>
         </CardHeader>
       </Card>

--- a/src/app/(protected)/concern-topics/actions.ts
+++ b/src/app/(protected)/concern-topics/actions.ts
@@ -59,7 +59,7 @@ export async function updateUserConcernTopicsAction(
   } catch (error) {
     if (error instanceof AuthenticationError) redirect("/signin");
     return failure(
-      error instanceof Error ? error.message : "関心ワードの更新に失敗しました",
+      error instanceof Error ? error.message : "関心トピックの更新に失敗しました",
     );
   }
 }

--- a/src/app/(protected)/concern-topics/loading.tsx
+++ b/src/app/(protected)/concern-topics/loading.tsx
@@ -11,7 +11,7 @@ export default function ConcernTopicsLoading() {
           <Skeleton className="h-5 w-72" />
         </div>
 
-        {/* 関心ワードカード */}
+        {/* 関心トピックカード */}
         <Card>
           <CardHeader className="space-y-2">
             <Skeleton className="h-6 w-48" />

--- a/src/app/(protected)/concern-topics/page.tsx
+++ b/src/app/(protected)/concern-topics/page.tsx
@@ -6,7 +6,7 @@ export default function ConcernTopicsPage() {
       <div className="max-w-2xl mx-auto">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
-            関心ワード
+            関心トピック
           </h1>
           <p className="text-gray-600 dark:text-gray-400 mt-2">
             気になる体調・環境を登録すると、よりあなたに合った提案を受け取れます

--- a/src/app/(protected)/onboarding/welcome/_components/CompletionScreen.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/CompletionScreen.tsx
@@ -30,7 +30,7 @@ export function CompletionScreen({
     },
     {
       icon: Heart,
-      label: "関心ワード",
+      label: "関心トピック",
       value: `${concernTopicsCount}件登録`,
     },
     {

--- a/src/app/(protected)/onboarding/welcome/_components/onboarding-steps.config.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/onboarding-steps.config.tsx
@@ -40,7 +40,7 @@ export const STEP_DEFINITIONS: StepDefinition[] = [
   },
   {
     key: "concern_topics",
-    title: "関心ワードを登録する",
+    title: "関心トピックを登録する",
     description:
       "気になる体調・環境を選ぶと、よりあなたに合った提案をお届けします。",
     subtitle: "ステップ2: 気になる項目を選びましょう",
@@ -56,7 +56,7 @@ export const STEP_DEFINITIONS: StepDefinition[] = [
           <li>選んだ項目に合わせた行動提案を優先的に表示</li>
           <li>気になることがなければ選ばなくても大丈夫です</li>
         </ul>
-        <p className="pt-2">あとから関心ワードページでいつでも変更できます。</p>
+        <p className="pt-2">あとから関心トピックページでいつでも変更できます。</p>
       </div>
     ),
   },

--- a/src/app/(protected)/onboarding/welcome/_components/steps/ConcernTopicsStep.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/steps/ConcernTopicsStep.tsx
@@ -46,13 +46,13 @@ export function ConcernTopicsStep({
         Array.from(selectedKeys),
       );
       if (result.status === "success") {
-        toast.success("関心ワードを登録しました");
+        toast.success("関心トピックを登録しました");
         onComplete(selectedKeys.size);
       } else {
         toast.error(result.error?.message ?? "登録に失敗しました");
       }
     } catch {
-      toast.error("関心ワードの登録に失敗しました");
+      toast.error("関心トピックの登録に失敗しました");
     } finally {
       setSaving(false);
     }
@@ -62,7 +62,7 @@ export function ConcernTopicsStep({
     return (
       <div className="rounded-lg border border-border bg-card p-6 space-y-4">
         <p className="text-sm text-muted-foreground">
-          登録できる関心ワードはありません
+          登録できる関心トピックはありません
         </p>
         <Button className="w-full" onClick={onSkip}>
           次へ進む
@@ -101,7 +101,7 @@ export function ConcernTopicsStep({
         variant="ghost"
         className="w-full"
         onClick={() => {
-          toast.info("関心ワードはいつでも登録できます");
+          toast.info("関心トピックはいつでも登録できます");
           onSkip();
         }}
         disabled={saving}

--- a/src/app/(protected)/onboarding/welcome/page.tsx
+++ b/src/app/(protected)/onboarding/welcome/page.tsx
@@ -46,7 +46,7 @@ export default async function OnboardingWelcomePage() {
     concernTopics = topicsData ?? [];
     initialSelectedKeys = userKeys ?? [];
   } catch {
-    // 関心ワードの取得失敗時は空配列のまま進める
+    // 関心トピックの取得失敗時は空配列のまま進める
   }
 
   return (

--- a/src/lib/api/action-result.ts
+++ b/src/lib/api/action-result.ts
@@ -1,7 +1,7 @@
 /**
  * Server Actions の統一戻り値型
  *
- * フォーム送信以外（プッシュ通知の登録/解除、関心ワード更新等）で使用する。
+ * フォーム送信以外（プッシュ通知の登録/解除、関心トピック更新等）で使用する。
  * Conform を使ったフォームアクションは SubmissionResult を使う。
  */
 export type ActionResult<T = void> =

--- a/src/lib/api/concern-topics.ts
+++ b/src/lib/api/concern-topics.ts
@@ -50,7 +50,7 @@ export async function fetchConcernTopics(
   checkAuthError(res);
 
   if (!res.ok) {
-    throw new Error(`関心ワードの取得に失敗しました: ${res.statusText}`);
+    throw new Error(`関心トピックの取得に失敗しました: ${res.statusText}`);
   }
 
   const json = await res.json();
@@ -68,7 +68,7 @@ export async function fetchUserConcernTopics(
   checkAuthError(res);
 
   if (!res.ok) {
-    throw new Error(`ユーザーの関心ワード取得に失敗しました: ${res.statusText}`);
+    throw new Error(`ユーザーの関心トピック取得に失敗しました: ${res.statusText}`);
   }
 
   const json = await res.json();
@@ -92,6 +92,6 @@ export async function updateUserConcernTopics(
   checkAuthError(res);
 
   if (!res.ok) {
-    throw new Error(`関心ワードの更新に失敗しました: ${res.statusText}`);
+    throw new Error(`関心トピックの更新に失敗しました: ${res.statusText}`);
   }
 }


### PR DESCRIPTION
# 概要
アプリ内の日本語表示で使用している「関心ワード」を「関心トピック」に統一する文言変更。

# 目的
- 「ワード（単語）」よりも「トピック（話題・テーマ）」の方が、健康関連の選択項目を表す文言として適切
- 英語識別子 `concern_topics` と日本語表示の整合性を取る

# 変更内容
- ページタイトル・UIラベル（3箇所）: `page.tsx`, `ConcernTopicsForm.tsx`, `DashboardMenu.tsx`
- トースト・エラーメッセージ（8箇所）: `concern-topics.ts`, `ConcernTopicsForm.tsx`, `actions.ts`
- オンボーディング（6箇所）: `ConcernTopicsStep.tsx`, `onboarding-steps.config.tsx`, `CompletionScreen.tsx`
- コメント（3箇所）: `action-result.ts`, `loading.tsx`, `welcome/page.tsx`

# 影響範囲
- ユーザー向け表示の文言変更のみ。機能・API・DBへの影響なし

# 関連ブランチ名
- back: `refactor/back/rename-concern-word-to-topic`