### PR TITLE
Add account deletion UI to settings page

### DIFF
--- a/src/app/(protected)/settings/_components/AccountDeleteSection.tsx
+++ b/src/app/(protected)/settings/_components/AccountDeleteSection.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Trash2, AlertTriangle } from "lucide-react";
+import { deleteAccountAction } from "../actions";
+
+type Props = {
+  isOAuthUser: boolean;
+};
+
+export function AccountDeleteSection({ isOAuthUser }: Props) {
+  const [open, setOpen] = useState(false);
+  const [password, setPassword] = useState("");
+  const [confirmText, setConfirmText] = useState("");
+  const [error, setError] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const canSubmit = isOAuthUser ? confirmText === "削除" : password.length > 0;
+
+  const handleDelete = () => {
+    setError("");
+    startTransition(async () => {
+      const result = await deleteAccountAction(
+        isOAuthUser ? { confirm: true } : { password },
+      );
+      if (!result.success) {
+        setError(result.error || "アカウントの削除に失敗しました");
+      }
+    });
+  };
+
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) {
+      setPassword("");
+      setConfirmText("");
+      setError("");
+    }
+  };
+
+  return (
+    <Card className="border-red-200 dark:border-red-800/50">
+      <CardContent className="py-4">
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+          <DialogTrigger asChild>
+            <button
+              type="button"
+              className="flex items-center gap-3 w-full p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors cursor-pointer"
+            >
+              <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-red-100 dark:bg-red-900/50">
+                <Trash2 className="h-5 w-5 text-red-600 dark:text-red-400" />
+              </div>
+              <span className="text-red-600 dark:text-red-400 font-medium">
+                アカウントを削除する
+              </span>
+            </button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <AlertTriangle className="h-5 w-5 text-red-500" />
+                アカウント削除の確認
+              </DialogTitle>
+              <DialogDescription>
+                すべてのデータが完全に削除されます。この操作は取り消せません。
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4 py-2">
+              {isOAuthUser ? (
+                <div className="space-y-2">
+                  <label
+                    htmlFor="confirm-text"
+                    className="text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    確認のため「削除」と入力してください
+                  </label>
+                  <Input
+                    id="confirm-text"
+                    value={confirmText}
+                    onChange={(e) => setConfirmText(e.target.value)}
+                    placeholder="削除"
+                    disabled={isPending}
+                  />
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <label
+                    htmlFor="password"
+                    className="text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    確認のためパスワードを入力してください
+                  </label>
+                  <Input
+                    id="password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="パスワード"
+                    disabled={isPending}
+                  />
+                </div>
+              )}
+              {error && (
+                <p className="text-sm text-red-600 dark:text-red-400">
+                  {error}
+                </p>
+              )}
+            </div>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isPending}
+              >
+                キャンセル
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleDelete}
+                disabled={!canSubmit || isPending}
+              >
+                {isPending ? "削除中..." : "アカウントを削除する"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -2,6 +2,7 @@ import { auth } from "@/auth";
 import { AlertTriangle } from "lucide-react";
 import { ProfileEditForm } from "./_components/ProfileEditForm";
 import { AccountInfo } from "./_components/AccountInfo";
+import { AccountDeleteSection } from "./_components/AccountDeleteSection";
 import { getProfileAction, getPrefectures } from "./actions";
 import { NotificationSettings } from "@/components/NotificationSettings";
 import { Card, CardContent } from "@/components/ui/card";
@@ -74,20 +75,28 @@ export default async function SettingsPage() {
             <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
               アカウント管理
             </h2>
-            <Card>
-              <CardContent className="py-4">
-                <LogoutButton>
-                  <div className="flex items-center gap-3 w-full p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors">
-                    <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-red-100 dark:bg-red-900/50">
-                      <LogOut className="h-5 w-5 text-red-600 dark:text-red-400" />
+            <div className="space-y-4">
+              <Card>
+                <CardContent className="py-4">
+                  <LogoutButton>
+                    <div className="flex items-center gap-3 w-full p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors">
+                      <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-red-100 dark:bg-red-900/50">
+                        <LogOut className="h-5 w-5 text-red-600 dark:text-red-400" />
+                      </div>
+                      <span className="text-red-600 dark:text-red-400 font-medium">
+                        ログアウト
+                      </span>
                     </div>
-                    <span className="text-red-600 dark:text-red-400 font-medium">
-                      ログアウト
-                    </span>
-                  </div>
-                </LogoutButton>
-              </CardContent>
-            </Card>
+                  </LogoutButton>
+                </CardContent>
+              </Card>
+              <AccountDeleteSection
+                isOAuthUser={
+                  !!session?.user?.image &&
+                  session.user.image.includes("googleusercontent.com")
+                }
+              />
+            </div>
           </section>
         </div>
       </div>


### PR DESCRIPTION
# 概要
設定ページにアカウント削除セクションを追加し、ユーザーが自身のアカウントを削除できるUIを実装。

# 目的
プライバシーポリシー第8条で明記している「アカウント削除の権利」を実装し、法的整合性を確保する。

# 変更内容
- `AccountDeleteSection` コンポーネント新規作成
  - shadcn/ui Dialog による確認ダイアログ
  - パスワード認証ユーザー: パスワード入力フィールド
  - OAuthユーザー: 「削除」テキスト入力による確認
- `deleteAccountAction` Server Action 追加（DELETE API呼び出し → Cookie/セッションクリア → リダイレクト）
- 設定ページのアカウント管理セクションにコンポーネントを配置

# 影響範囲
- 設定ページ（`/settings`）のUIに「アカウント削除」セクション追加
- 既存の機能やUIへの影響なし

# 関連ブランチ名
`feat/back/account-deletion` (Climode_back)