### PR TITLE
Normalize deprecated Tailwind CSS v4 class names

### DIFF
--- a/src/app/(auth)/about/loading.tsx
+++ b/src/app/(auth)/about/loading.tsx
@@ -2,7 +2,7 @@ import { Loading } from "@/components/ui/loading";
 
 export default function AboutLoading() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4 py-12">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4 py-12">
       <Loading size="lg" text="読み込み中..." className="min-h-[50vh]" />
     </div>
   );

--- a/src/app/(auth)/about/page.tsx
+++ b/src/app/(auth)/about/page.tsx
@@ -58,7 +58,7 @@ const FEATURES = [
 
 export default function AboutPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4 py-12">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4 py-12">
       <div className="w-full max-w-3xl mx-auto space-y-12">
         {/* サービス概要 */}
         <section className="text-center space-y-4">

--- a/src/app/(auth)/error/page.tsx
+++ b/src/app/(auth)/error/page.tsx
@@ -33,7 +33,7 @@ function AuthErrorContent() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
           <CardTitle className="text-2xl font-bold text-center flex items-center justify-center gap-2">
@@ -77,7 +77,7 @@ export default function AuthErrorPage() {
   return (
     <Suspense
       fallback={
-        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4">
+        <div className="min-h-screen flex items-center justify-center bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4">
           <Card className="w-full max-w-md">
             <CardHeader className="space-y-1">
               <CardTitle className="text-2xl font-bold text-center flex items-center justify-center gap-2">

--- a/src/app/(auth)/privacy-policy/page.tsx
+++ b/src/app/(auth)/privacy-policy/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 
 export default function PrivacyPolicyPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4 py-12">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4 py-12">
       <Card className="w-full max-w-3xl mx-auto">
         <CardHeader className="space-y-1">
           <CardTitle className="text-2xl font-bold text-center">

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -23,7 +23,7 @@ interface SignInPageProps {
 export default async function SignInPage({ searchParams }: SignInPageProps) {
   const params = await searchParams;
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
           <div className="flex justify-center">

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 
 export default async function SignUpPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
           <div className="flex justify-center">

--- a/src/app/(auth)/terms-of-service/page.tsx
+++ b/src/app/(auth)/terms-of-service/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
 
 export default function TermsOfServicePage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4 py-12">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-4 py-12">
       <Card className="w-full max-w-3xl mx-auto">
         <CardHeader className="space-y-1">
           <CardTitle className="text-2xl font-bold text-center">

--- a/src/app/(protected)/_components/DashboardMenu.tsx
+++ b/src/app/(protected)/_components/DashboardMenu.tsx
@@ -119,7 +119,7 @@ export default function DashboardMenu({ user }: Props) {
         </DialogHeader>
 
         <Link href="/settings">
-          <div className="flex items-center gap-4 p-4 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/40 dark:to-indigo-950/40 rounded-xl mb-4 hover:shadow-md transition-shadow">
+          <div className="flex items-center gap-4 p-4 bg-linear-to-r from-blue-50 to-indigo-50 dark:from-blue-950/40 dark:to-indigo-950/40 rounded-xl mb-4 hover:shadow-md transition-shadow">
             <Avatar className="h-12 w-12 ring-2 ring-blue-200 dark:ring-blue-800">
               <AvatarImage src={user.image || ""} alt={user.name || ""} />
               <AvatarFallback className="bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400 font-semibold">

--- a/src/app/(protected)/dailylog/[id]/page.tsx
+++ b/src/app/(protected)/dailylog/[id]/page.tsx
@@ -11,7 +11,7 @@ export default async function DailyLogPage({
   params: { id: string };
 }) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       <div className="container mx-auto px-4 py-8 space-y-4">
         <Link
           href="/calendar"

--- a/src/app/(protected)/evening/loading.tsx
+++ b/src/app/(protected)/evening/loading.tsx
@@ -3,7 +3,7 @@ import { Loading } from "@/components/ui/loading";
 
 export default function EveningLoading() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-2xl mx-auto">
           {/* ヘッダー */}

--- a/src/app/(protected)/evening/page.tsx
+++ b/src/app/(protected)/evening/page.tsx
@@ -12,7 +12,7 @@ export default async function EveningPage() {
   ]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-2xl mx-auto">
           {/* ヘッダー */}

--- a/src/app/(protected)/morning/loading.tsx
+++ b/src/app/(protected)/morning/loading.tsx
@@ -2,7 +2,7 @@ import { Loading } from "@/components/ui/loading";
 
 export default function MorningLoading() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-2xl mx-auto">
           {/* ヘッダー */}

--- a/src/app/(protected)/morning/page.tsx
+++ b/src/app/(protected)/morning/page.tsx
@@ -6,7 +6,7 @@ export default async function MorningPage() {
   const today = new Date();
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-2xl mx-auto">
           {/* 挨拶と日付 */}

--- a/src/app/(protected)/onboarding/welcome/loading.tsx
+++ b/src/app/(protected)/onboarding/welcome/loading.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 export default function OnboardingLoading() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       <div className="container mx-auto max-w-4xl px-4 py-12">
         <Card className="shadow-xl border-primary/10">
           <CardHeader>

--- a/src/app/(protected)/onboarding/welcome/page.tsx
+++ b/src/app/(protected)/onboarding/welcome/page.tsx
@@ -50,7 +50,7 @@ export default async function OnboardingWelcomePage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       <div className="container mx-auto max-w-4xl px-4 py-12">
         <OnboardingWizard
           prefectures={prefectures}

--- a/src/app/(protected)/reports/weekly/loading.tsx
+++ b/src/app/(protected)/reports/weekly/loading.tsx
@@ -3,7 +3,7 @@ import { BarChart3 } from "lucide-react";
 
 export default function WeeklyReportLoading() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       <div className="container mx-auto px-4 py-8">
         {/* Header */}
         <div className="mb-6">

--- a/src/app/(protected)/reports/weekly/page.tsx
+++ b/src/app/(protected)/reports/weekly/page.tsx
@@ -63,7 +63,7 @@ export default async function WeeklyReportPage({
   const { start } = await searchParams;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       <div className="container mx-auto px-4 py-8">
         {/* Header */}
         <div className="mb-6">


### PR DESCRIPTION
# 概要
Tailwind CSS v4 で非推奨となった `bg-gradient-to-*` クラスを正規クラス名 `bg-linear-to-*` に一括置換する。

# 目的
- `suggestCanonicalClasses` 警告の解消
- 将来のメジャーバージョンで削除される可能性がある非推奨クラスの事前移行
- コードベース全体の一貫性確保

# 変更内容
- `bg-gradient-to-br` → `bg-linear-to-br`（17箇所、16ファイル）
- `bg-gradient-to-r` → `bg-linear-to-r`（1箇所、1ファイル）
- 合計: 17ファイル・18箇所

# 影響範囲
- 見た目の変化なし（Tailwind の別名クラスで同じCSSを生成）
- 機能的な影響なし
- API・DBの変更なし

# 関連ブランチ名
なし（frontのみの変更）

Closes #115