### PR TITLE
Fix footer gap caused by min-h-screen on individual pages

### DIFF
--- a/src/app/(protected)/calendar/page.tsx
+++ b/src/app/(protected)/calendar/page.tsx
@@ -6,7 +6,7 @@ export default async function CalendarPage() {
 
   if (!dailyLogs) {
     return (
-      <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
+      <div className="bg-slate-50 dark:bg-slate-950">
         <div className="container mx-auto px-4 py-4 lg:px-8">
           <div className="text-center text-muted-foreground py-12">
             <p>記録データを取得できませんでした。</p>
@@ -20,7 +20,7 @@ export default async function CalendarPage() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
+    <div className="bg-slate-50 dark:bg-slate-950">
       <div className="container mx-auto px-4 py-4 lg:px-8">
         <div className="space-y-4">
           {/* ヘッダーセクション */}

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -25,7 +25,7 @@ export default async function DashboardPage() {
   const emailConfirmed = profile?.user?.email_confirmed !== false;
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
+    <div className="bg-slate-50 dark:bg-slate-950">
       <div className="container mx-auto px-4 py-4 lg:px-8">
         <div className="space-y-6">
           {!emailConfirmed && <EmailConfirmationBanner />}

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -7,9 +7,9 @@ export default async function DashboardLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div>
+    <div className="flex min-h-screen flex-col">
       <Header />
-      {children}
+      <main className="flex-1">{children}</main>
       <Footer />
     </div>
   );

--- a/src/app/(protected)/morning/page.tsx
+++ b/src/app/(protected)/morning/page.tsx
@@ -14,7 +14,7 @@ export default async function MorningPage() {
   const today = new Date();
 
   return (
-    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+    <div className="bg-linear-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-2xl mx-auto">
           {/* 挨拶と日付 */}


### PR DESCRIPTION
# 概要
認証済みページでコンテンツとフッターの間に大きな空白が表示される問題を修正

# 目的
- コンテンツが少ないページでもフッターが自然な位置に表示されるようにする
- `min-h-screen` の管理をレイアウト側に統一し、各ページの責務を軽減する

# 変更内容
- `(protected)/layout.tsx`: Sticky Footer パターンを適用（`flex min-h-screen flex-col` + `<main className="flex-1">`）
- `dashboard/page.tsx`: `min-h-screen` を除去（背景色は維持）
- `calendar/page.tsx`: 2箇所の `min-h-screen` を除去（背景色は維持）
- `morning/page.tsx`: `min-h-screen` を除去（グラデーション背景は維持）

# 影響範囲
- 認証済みページ全体のレイアウト（Header / コンテンツ / Footer の配置）
- 見た目の変更のみで、機能的な変更はなし

# 関連ブランチ名
なし（フロントエンドのみの変更）

Closes #133