### PR TITLE
Update URLs for custom domain (climode.app)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://climode-front.vercel.app"),
+  metadataBase: new URL("https://climode.app"),
   title: {
     default: "Climode - 体調管理アプリ",
     template: "%s - Climode",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,7 +29,7 @@ export default async function Home() {
     name: "Climode",
     description:
       "睡眠・気分・症状などの身体データと、天気・気圧・湿度などの環境データを統合して体調をスコア化する健康管理アプリ",
-    url: "https://climode-front.vercel.app",
+    url: "https://climode.app",
     applicationCategory: "HealthApplication",
     operatingSystem: "Web",
     offers: {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -24,6 +24,6 @@ export default function robots(): MetadataRoute.Robots {
         ],
       },
     ],
-    sitemap: "https://climode-front.vercel.app/sitemap.xml",
+    sitemap: "https://climode.app/sitemap.xml",
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = "https://climode-front.vercel.app";
+  const baseUrl = "https://climode.app";
 
   return [
     {


### PR DESCRIPTION
# 概要
カスタムドメイン `climode.app` に対応するためのフロントエンドURL設定の更新

# 目的
独自ドメインでサービスを公開し、SEO・OGP・サイトマップのURLを統一する

# 変更内容
- `layout.tsx`: metadataBase を `https://climode.app` に変更
- `page.tsx`: JSON-LD の url を `https://climode.app` に変更
- `robots.ts`: sitemap URL を `https://climode.app/sitemap.xml` に変更
- `sitemap.ts`: baseUrl を `https://climode.app` に変更

# 影響範囲
- SEOメタデータ（OGP、sitemap、robots.txt）
- 構造化データ（JSON-LD）

# 関連ブランチ名
- Back: `chore/back/custom-domain`