### PR TITLE
Add tab layout to settings page

### DIFF
--- a/src/app/(protected)/settings/_components/AccountDeleteSection.tsx
+++ b/src/app/(protected)/settings/_components/AccountDeleteSection.tsx
@@ -3,7 +3,6 @@
 import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Card, CardContent } from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -51,9 +50,8 @@ export function AccountDeleteSection({ isOAuthUser }: Props) {
   };
 
   return (
-    <Card className="border-red-200 dark:border-red-800/50">
-      <CardContent className="py-4">
-        <Dialog open={open} onOpenChange={handleOpenChange}>
+    <div>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
           <DialogTrigger asChild>
             <button
               type="button"
@@ -135,8 +133,7 @@ export function AccountDeleteSection({ isOAuthUser }: Props) {
               </Button>
             </DialogFooter>
           </DialogContent>
-        </Dialog>
-      </CardContent>
-    </Card>
+      </Dialog>
+    </div>
   );
 }

--- a/src/app/(protected)/settings/_components/AccountInfo.tsx
+++ b/src/app/(protected)/settings/_components/AccountInfo.tsx
@@ -1,5 +1,4 @@
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { Card, CardContent } from "@/components/ui/card";
 import { Mail, Shield } from "lucide-react";
 
 type AccountInfoProps = {
@@ -21,30 +20,28 @@ export function AccountInfo({ user }: AccountInfoProps) {
   const authMethod = getAuthMethod(user.image);
 
   return (
-    <Card>
-      <CardContent className="flex items-center gap-4 py-6">
-        <Avatar className="h-16 w-16 ring-2 ring-blue-200 dark:ring-blue-800">
-          <AvatarImage src={user.image || ""} alt={`${user.name || "ユーザー"}のプロフィール画像`} />
-          <AvatarFallback className="bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400 font-semibold text-lg">
-            {user.name?.charAt(0) || user.email?.charAt(0) || "U"}
-          </AvatarFallback>
-        </Avatar>
-        <div className="flex-1 min-w-0 space-y-1">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white truncate">
-            {user.name || "ユーザー"}
-          </h3>
-          {user.email && (
-            <div className="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400">
-              <Mail className="h-3.5 w-3.5" />
-              <span className="truncate">{user.email}</span>
-            </div>
-          )}
-          <div className="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-500">
-            <Shield className="h-3.5 w-3.5" />
-            <span>{authMethod}</span>
+    <div className="flex items-center gap-4">
+      <Avatar className="h-16 w-16 ring-2 ring-blue-200 dark:ring-blue-800">
+        <AvatarImage src={user.image || ""} alt={`${user.name || "ユーザー"}のプロフィール画像`} />
+        <AvatarFallback className="bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400 font-semibold text-lg">
+          {user.name?.charAt(0) || user.email?.charAt(0) || "U"}
+        </AvatarFallback>
+      </Avatar>
+      <div className="flex-1 min-w-0 space-y-1">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white truncate">
+          {user.name || "ユーザー"}
+        </h3>
+        {user.email && (
+          <div className="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400">
+            <Mail className="h-3.5 w-3.5" />
+            <span className="truncate">{user.email}</span>
           </div>
+        )}
+        <div className="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-500">
+          <Shield className="h-3.5 w-3.5" />
+          <span>{authMethod}</span>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/src/app/(protected)/settings/_components/CookieSettings.tsx
+++ b/src/app/(protected)/settings/_components/CookieSettings.tsx
@@ -3,13 +3,7 @@
 import { useState, useEffect } from "react";
 import { Cookie } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
 import { getCookieConsent, setCookieConsent } from "@/lib/cookie-consent";
 import type { CookieConsentValue } from "@/lib/cookie-consent";
 
@@ -31,47 +25,45 @@ export function CookieSettings() {
   if (!mounted) return null;
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Cookie className="h-5 w-5" />
+    <div className="space-y-3">
+      <div>
+        <Label className="flex items-center gap-2">
+          <Cookie className="h-4 w-4" />
           Cookie設定
-        </CardTitle>
-        <CardDescription>
+        </Label>
+        <p className="text-sm text-muted-foreground mt-1">
           アクセス解析（Google Analytics）のCookie使用について設定できます
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex items-center justify-between">
-          <div className="space-y-1">
-            <p className="text-sm font-medium">
-              {consent === "accepted"
-                ? "Cookieを許可中"
-                : consent === "rejected"
-                  ? "Cookieを拒否中"
-                  : "未設定"}
-            </p>
-            <p className="text-sm text-muted-foreground">
-              {consent === "accepted"
-                ? "サービス改善のためのアクセス解析データが送信されます"
-                : "アクセス解析用のCookieは使用されていません"}
-            </p>
-          </div>
-          {consent === "accepted" ? (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => handleChange("rejected")}
-            >
-              拒否する
-            </Button>
-          ) : (
-            <Button size="sm" onClick={() => handleChange("accepted")}>
-              許可する
-            </Button>
-          )}
+        </p>
+      </div>
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">
+            {consent === "accepted"
+              ? "Cookieを許可中"
+              : consent === "rejected"
+                ? "Cookieを拒否中"
+                : "未設定"}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {consent === "accepted"
+              ? "サービス改善のためのアクセス解析データが送信されます"
+              : "アクセス解析用のCookieは使用されていません"}
+          </p>
         </div>
-      </CardContent>
-    </Card>
+        {consent === "accepted" ? (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handleChange("rejected")}
+          >
+            拒否する
+          </Button>
+        ) : (
+          <Button size="sm" onClick={() => handleChange("accepted")}>
+            許可する
+          </Button>
+        )}
+      </div>
+    </div>
   );
 }

--- a/src/app/(protected)/settings/_components/ProfileEditForm.tsx
+++ b/src/app/(protected)/settings/_components/ProfileEditForm.tsx
@@ -6,7 +6,6 @@ import { useActionState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Card, CardContent } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Loader2, User, MapPin } from "lucide-react";
 import { profileSchema } from "@/lib/schemas/profile";
@@ -59,15 +58,14 @@ export function ProfileEditForm({ initialData, prefectures }: ProfileEditFormPro
   });
 
   return (
-    <Card className="w-full max-w-2xl mx-auto">
-      <CardContent>
-        <form
-          id={form.id}
-          onSubmit={form.onSubmit}
-          action={action}
-          className="space-y-6"
-          aria-label="プロフィール編集"
-        >
+    <div>
+      <form
+        id={form.id}
+        onSubmit={form.onSubmit}
+        action={action}
+        className="space-y-6"
+        aria-label="プロフィール編集"
+      >
           {form.errors && (
             <Alert variant="destructive">
               <AlertDescription>
@@ -137,8 +135,7 @@ export function ProfileEditForm({ initialData, prefectures }: ProfileEditFormPro
               更新する
             </Button>
           </div>
-        </form>
-      </CardContent>
-    </Card>
+      </form>
+    </div>
   );
 }

--- a/src/app/(protected)/settings/_components/SettingsTabs.tsx
+++ b/src/app/(protected)/settings/_components/SettingsTabs.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Separator } from "@/components/ui/separator";
+import { Card, CardContent } from "@/components/ui/card";
+import { AccountInfo } from "./AccountInfo";
+import { ProfileEditForm } from "./ProfileEditForm";
+import { AccountDeleteSection } from "./AccountDeleteSection";
+import { CookieSettings } from "./CookieSettings";
+import { NotificationSettings } from "@/components/NotificationSettings";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import LogoutButton from "../../_components/LogoutButton";
+import { LogOut } from "lucide-react";
+
+type Prefecture = {
+  id: number;
+  code: string;
+  name_ja: string;
+};
+
+type SettingsTabsProps = {
+  user: {
+    name?: string | null;
+    email?: string | null;
+    image?: string | null;
+  };
+  profile: {
+    user: {
+      name: string;
+      prefecture_id?: number;
+    };
+  };
+  prefectures: Prefecture[];
+  isOAuthUser: boolean;
+};
+
+export function SettingsTabs({
+  user,
+  profile,
+  prefectures,
+  isOAuthUser,
+}: SettingsTabsProps) {
+  return (
+    <Tabs defaultValue="profile">
+      <TabsList className="w-full">
+        <TabsTrigger value="profile">プロフィール</TabsTrigger>
+        <TabsTrigger value="general">一般</TabsTrigger>
+        <TabsTrigger value="account">アカウント</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="profile">
+        <Card>
+          <CardContent className="space-y-6">
+            <AccountInfo user={user} />
+            <Separator />
+            <ProfileEditForm
+              initialData={{
+                name: profile.user.name || "",
+                prefecture_id: profile.user.prefecture_id,
+              }}
+              prefectures={prefectures}
+            />
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      <TabsContent value="general">
+        <Card>
+          <CardContent className="space-y-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium text-gray-900 dark:text-white">
+                  テーマ
+                </p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  アプリの外観を切り替えます
+                </p>
+              </div>
+              <ThemeToggle />
+            </div>
+            <Separator />
+            <NotificationSettings />
+            <Separator />
+            <CookieSettings />
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      <TabsContent value="account">
+        <Card>
+          <CardContent className="space-y-6">
+            <LogoutButton>
+              <div className="flex items-center gap-3 w-full p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors">
+                <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-red-100 dark:bg-red-900/50">
+                  <LogOut className="h-5 w-5 text-red-600 dark:text-red-400" />
+                </div>
+                <span className="text-red-600 dark:text-red-400 font-medium">
+                  ログアウト
+                </span>
+              </div>
+            </LogoutButton>
+            <Separator />
+            <AccountDeleteSection isOAuthUser={isOAuthUser} />
+          </CardContent>
+        </Card>
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/src/app/(protected)/settings/loading.tsx
+++ b/src/app/(protected)/settings/loading.tsx
@@ -1,5 +1,4 @@
 import { Card, CardContent } from "@/components/ui/card";
-import { Loading } from "@/components/ui/loading";
 
 export default function SettingsLoading() {
   return (
@@ -10,39 +9,40 @@ export default function SettingsLoading() {
           <div className="h-5 w-56 bg-slate-200 dark:bg-slate-700 rounded animate-pulse mt-2" />
         </div>
 
-        <div className="space-y-8">
-          {/* アカウント情報スケルトン */}
-          <section>
-            <div className="h-6 w-32 bg-slate-200 dark:bg-slate-700 rounded animate-pulse mb-4" />
-            <Card className="mb-4">
-              <CardContent className="flex items-center gap-4 py-6">
-                <div className="h-16 w-16 rounded-full bg-slate-200 dark:bg-slate-700 animate-pulse" />
-                <div className="space-y-2 flex-1">
-                  <div className="h-5 w-32 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
-                  <div className="h-4 w-48 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
-                  <div className="h-4 w-36 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
-                </div>
-              </CardContent>
-            </Card>
-            <Card className="w-full max-w-2xl mx-auto">
-              <CardContent className="space-y-6 pt-6">
-                <div className="space-y-2">
-                  <div className="h-5 w-28 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
-                  <div className="h-10 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
-                </div>
-                <div className="space-y-2">
-                  <div className="h-5 w-20 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
-                  <div className="h-10 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
-                </div>
-                <div className="flex justify-end">
-                  <div className="h-10 w-24 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
-                </div>
-              </CardContent>
-            </Card>
-          </section>
-
-          <Loading size="lg" text="設定を読み込み中..." />
+        {/* TabsList スケルトン */}
+        <div className="flex gap-1 bg-muted rounded-lg p-1 mb-4">
+          <div className="flex-1 h-8 bg-slate-200 dark:bg-slate-700 rounded-md animate-pulse" />
+          <div className="flex-1 h-8 bg-slate-200 dark:bg-slate-700 rounded-md animate-pulse" />
+          <div className="flex-1 h-8 bg-slate-200 dark:bg-slate-700 rounded-md animate-pulse" />
         </div>
+
+        {/* TabsContent スケルトン（プロフィールタブ相当） */}
+        <Card>
+          <CardContent className="space-y-6">
+            <div className="flex items-center gap-4">
+              <div className="h-16 w-16 rounded-full bg-slate-200 dark:bg-slate-700 animate-pulse" />
+              <div className="space-y-2 flex-1">
+                <div className="h-5 w-32 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                <div className="h-4 w-48 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                <div className="h-4 w-36 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              </div>
+            </div>
+            <div className="h-px bg-slate-200 dark:bg-slate-700" />
+            <div className="space-y-6">
+              <div className="space-y-2">
+                <div className="h-5 w-28 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                <div className="h-10 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              </div>
+              <div className="space-y-2">
+                <div className="h-5 w-20 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                <div className="h-10 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              </div>
+              <div className="flex justify-end">
+                <div className="h-10 w-24 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -1,15 +1,8 @@
 import { auth } from "@/auth";
 import { AlertTriangle } from "lucide-react";
-import { ProfileEditForm } from "./_components/ProfileEditForm";
-import { AccountInfo } from "./_components/AccountInfo";
-import { AccountDeleteSection } from "./_components/AccountDeleteSection";
 import { getProfileAction, getPrefectures } from "./actions";
-import { NotificationSettings } from "@/components/NotificationSettings";
-import { ThemeToggle } from "@/components/ThemeToggle";
-import { CookieSettings } from "./_components/CookieSettings";
 import { Card, CardContent } from "@/components/ui/card";
-import LogoutButton from "../_components/LogoutButton";
-import { LogOut } from "lucide-react";
+import { SettingsTabs } from "./_components/SettingsTabs";
 
 export default async function SettingsPage() {
   const session = await auth();
@@ -46,87 +39,15 @@ export default async function SettingsPage() {
           </p>
         </div>
 
-        <div className="space-y-8">
-          {/* セクション A: アカウント情報 */}
-          <section>
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-              アカウント情報
-            </h2>
-            <div className="space-y-4">
-              <AccountInfo user={session?.user ?? {}} />
-              <ProfileEditForm
-                initialData={{
-                  name: profile?.user?.name || "",
-                  prefecture_id: profile?.user?.prefecture_id,
-                }}
-                prefectures={prefectures ?? []}
-              />
-            </div>
-          </section>
-
-          {/* セクション A2: 外観設定 */}
-          <section>
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-              外観設定
-            </h2>
-            <Card>
-              <CardContent className="flex items-center justify-between py-4">
-                <div>
-                  <p className="font-medium text-gray-900 dark:text-white">テーマ</p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
-                    アプリの外観を切り替えます
-                  </p>
-                </div>
-                <ThemeToggle />
-              </CardContent>
-            </Card>
-          </section>
-
-          {/* セクション B: 通知設定 */}
-          <section>
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-              通知設定
-            </h2>
-            <NotificationSettings />
-          </section>
-
-          {/* セクション B2: Cookie設定 */}
-          <section>
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-              Cookie設定
-            </h2>
-            <CookieSettings />
-          </section>
-
-          {/* セクション C: アカウント管理 */}
-          <section>
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-              アカウント管理
-            </h2>
-            <div className="space-y-4">
-              <Card>
-                <CardContent className="py-4">
-                  <LogoutButton>
-                    <div className="flex items-center gap-3 w-full p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors">
-                      <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-red-100 dark:bg-red-900/50">
-                        <LogOut className="h-5 w-5 text-red-600 dark:text-red-400" />
-                      </div>
-                      <span className="text-red-600 dark:text-red-400 font-medium">
-                        ログアウト
-                      </span>
-                    </div>
-                  </LogoutButton>
-                </CardContent>
-              </Card>
-              <AccountDeleteSection
-                isOAuthUser={
-                  !!session?.user?.image &&
-                  session.user.image.includes("googleusercontent.com")
-                }
-              />
-            </div>
-          </section>
-        </div>
+        <SettingsTabs
+          user={session?.user ?? {}}
+          profile={profile}
+          prefectures={prefectures ?? []}
+          isOAuthUser={
+            !!session?.user?.image &&
+            session.user.image.includes("googleusercontent.com")
+          }
+        />
       </div>
     </div>
   );

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -2,13 +2,7 @@
 
 import { Bell, BellOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { usePushNotification } from "@/hooks/use-push-notification";
@@ -54,32 +48,32 @@ export function NotificationSettings() {
 
   if (!isSupported) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <BellOff className="h-5 w-5" />
+      <div className="space-y-3">
+        <div>
+          <Label className="flex items-center gap-2">
+            <BellOff className="h-4 w-4" />
             プッシュ通知
-          </CardTitle>
-          <CardDescription>
+          </Label>
+          <p className="text-sm text-muted-foreground mt-1">
             お使いのブラウザはプッシュ通知に対応していません
-          </CardDescription>
-        </CardHeader>
-      </Card>
+          </p>
+        </div>
+      </div>
     );
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Bell className="h-5 w-5" />
+    <div className="space-y-3">
+      <div>
+        <Label className="flex items-center gap-2">
+          <Bell className="h-4 w-4" />
           プッシュ通知
-        </CardTitle>
-        <CardDescription>
+        </Label>
+        <p className="text-sm text-muted-foreground mt-1">
           朝8時は行動提案、夜20時は振り返りのリマインドを受け取る
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
+        </p>
+      </div>
+      <div className="space-y-4">
         {isLoading && !isSubscribed ? (
           <div className="flex items-center justify-between">
             <div className="space-y-2">
@@ -135,7 +129,7 @@ export function NotificationSettings() {
             )}
           </>
         )}
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
# 概要
設定画面の5セクション縦並び構成を、3タブ（プロフィール / 一般 / アカウント）構成に変更する。

# 目的
- 設定画面の情報量が多く散漫に見える問題を解消する
- タブで分類し1画面あたりの情報量を減らすことで、ユーザーが目的の設定にアクセスしやすくする

# 変更内容
- `SettingsTabs` クライアントコンポーネントを新規作成（shadcn/ui Tabs使用）
- `page.tsx` の5セクション構成を `SettingsTabs` に置き換え
- 各子コンポーネント（AccountInfo, ProfileEditForm, NotificationSettings, CookieSettings, AccountDeleteSection）から個別のCard要素を除去し、タブごとに1つのCardにまとめて表示
- `loading.tsx` をタブレイアウト対応のスケルトンに変更

# 影響範囲
- 設定画面（`/settings`）のレイアウトのみ
- 各設定コンポーネントの機能・ロジックに変更なし

# 関連ブランチ名
なし（フロントエンドのみの変更）

Closes #138