### PR TITLE
Add theme selection step to onboarding wizard

### DIFF
--- a/src/app/(protected)/onboarding/welcome/_components/CompletionScreen.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/CompletionScreen.tsx
@@ -7,12 +7,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { CheckCircle2, MapPin, Heart, Bell } from "lucide-react";
+import { CheckCircle2, MapPin, Heart, Bell, Palette } from "lucide-react";
 
 type CompletionScreenProps = {
   prefectureName: string | null;
   concernTopicsCount: number;
   notificationEnabled: boolean;
+  themeName: string;
   onGoToDashboard: () => void;
 };
 
@@ -20,6 +21,7 @@ export function CompletionScreen({
   prefectureName,
   concernTopicsCount,
   notificationEnabled,
+  themeName,
   onGoToDashboard,
 }: CompletionScreenProps) {
   const summaryItems = [
@@ -37,6 +39,11 @@ export function CompletionScreen({
       icon: Bell,
       label: "通知",
       value: notificationEnabled ? "有効" : "スキップ",
+    },
+    {
+      icon: Palette,
+      label: "外観",
+      value: themeName,
     },
   ];
 

--- a/src/app/(protected)/onboarding/welcome/_components/OnboardingWizard.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/OnboardingWizard.tsx
@@ -16,6 +16,7 @@ import { getStepTutorial } from "./StepTutorials";
 import { PrefectureStep } from "./steps/PrefectureStep";
 import { ConcernTopicsStep } from "./steps/ConcernTopicsStep";
 import { NotificationStep } from "./steps/NotificationStep";
+import { ThemeStep } from "./steps/ThemeStep";
 import { WelcomeScreen } from "./WelcomeScreen";
 import { CompletionScreen } from "./CompletionScreen";
 import { STEP_DEFINITIONS } from "@/lib/onboarding/steps-config";
@@ -65,6 +66,7 @@ export function OnboardingWizard({
   const [concernTopicsCount, setConcernTopicsCount] = useState(
     initialSelectedKeys.length
   );
+  const [selectedThemeName, setSelectedThemeName] = useState("システム");
 
   // Step transition animation
   const [displayedStepIndex, setDisplayedStepIndex] = useState(currentStepIndex);
@@ -109,6 +111,7 @@ export function OnboardingWizard({
         prefectureName={prefectureName}
         concernTopicsCount={concernTopicsCount}
         notificationEnabled={notificationEnabled}
+        themeName={skippedSteps.theme ? "システム" : selectedThemeName}
         onGoToDashboard={handleGoToDashboard}
       />
     );
@@ -148,6 +151,16 @@ export function OnboardingWizard({
           <NotificationStep
             onComplete={() => handleStepComplete("notification")}
             onSkip={() => handleStepSkip("notification")}
+          />
+        );
+      case "theme":
+        return (
+          <ThemeStep
+            onComplete={(themeName: string) => {
+              setSelectedThemeName(themeName);
+              handleStepComplete("theme");
+            }}
+            onSkip={() => handleStepSkip("theme")}
           />
         );
       default:

--- a/src/app/(protected)/onboarding/welcome/_components/StepTutorials.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/StepTutorials.tsx
@@ -44,6 +44,21 @@ const STEP_TUTORIALS: Record<StepKey, React.ReactNode> = {
       </p>
     </div>
   ),
+  theme: (
+    <div className="space-y-3 text-sm text-muted-foreground">
+      <p>
+        アプリの外観をお好みに合わせて選べます。選択するとすぐにプレビューされます。
+      </p>
+      <ul className="list-disc list-inside space-y-1 ml-2">
+        <li>ライト：明るい背景で見やすい表示</li>
+        <li>ダーク：目に優しい暗めの表示</li>
+        <li>システム：端末の設定に自動で合わせる</li>
+      </ul>
+      <p className="pt-2">
+        あとから設定ページでいつでも変更できます。
+      </p>
+    </div>
+  ),
 };
 
 export function getStepTutorial(key: StepKey): React.ReactNode {

--- a/src/app/(protected)/onboarding/welcome/_components/steps/ThemeStep.tsx
+++ b/src/app/(protected)/onboarding/welcome/_components/steps/ThemeStep.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Sun, Moon, Monitor } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type ThemeStepProps = {
+  onComplete: (themeName: string) => void;
+  onSkip: () => void;
+};
+
+const THEME_OPTIONS = [
+  { value: "light", label: "ライト", icon: Sun },
+  { value: "dark", label: "ダーク", icon: Moon },
+  { value: "system", label: "システム", icon: Monitor },
+] as const;
+
+const THEME_LABEL_MAP: Record<string, string> = {
+  light: "ライト",
+  dark: "ダーク",
+  system: "システム",
+};
+
+export function ThemeStep({ onComplete, onSkip }: ThemeStepProps) {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <div className="rounded-lg border p-6 space-y-4">
+        <div className="grid grid-cols-3 gap-3">
+          {THEME_OPTIONS.map((option) => (
+            <div
+              key={option.value}
+              className="rounded-lg border p-4 h-24 animate-pulse bg-muted/30"
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border p-6 space-y-4">
+      <div className="grid grid-cols-3 gap-3">
+        {THEME_OPTIONS.map((option) => {
+          const Icon = option.icon;
+          const isSelected = theme === option.value;
+
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => setTheme(option.value)}
+              className={`flex flex-col items-center justify-center gap-2 rounded-lg border p-4 transition-colors cursor-pointer ${
+                isSelected
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-muted hover:border-primary/50 hover:bg-muted/50"
+              }`}
+            >
+              <Icon className="h-6 w-6" />
+              <span className="text-sm font-medium">{option.label}</span>
+            </button>
+          );
+        })}
+      </div>
+      <Button
+        className="w-full"
+        onClick={() => onComplete(THEME_LABEL_MAP[theme ?? "system"])}
+      >
+        この設定で続ける
+      </Button>
+      <Button variant="ghost" className="w-full" onClick={onSkip}>
+        スキップ
+      </Button>
+    </div>
+  );
+}

--- a/src/hooks/use-onboarding-wizard.ts
+++ b/src/hooks/use-onboarding-wizard.ts
@@ -25,6 +25,7 @@ export function useOnboardingWizard({
     prefecture: initialPrefectureCompleted,
     concern_topics: false,
     notification: false,
+    theme: false,
   });
   const [skippedSteps, setSkippedSteps] = useState<SkippedSteps>({});
 
@@ -40,6 +41,7 @@ export function useOnboardingWizard({
       stepCompletion.prefecture &&
       stepCompletion.concern_topics &&
       stepCompletion.notification &&
+      stepCompletion.theme &&
       currentStepIndex === totalSteps - 1;
     if (allCompleted && phase === "steps") {
       setPhase("complete");

--- a/src/lib/onboarding/steps-config.ts
+++ b/src/lib/onboarding/steps-config.ts
@@ -1,7 +1,7 @@
 import type React from "react";
-import { Thermometer, Heart, Bell } from "lucide-react";
+import { Thermometer, Heart, Bell, Palette } from "lucide-react";
 
-export type StepKey = "prefecture" | "concern_topics" | "notification";
+export type StepKey = "prefecture" | "concern_topics" | "notification" | "theme";
 
 export type StepDefinition = {
   key: StepKey;
@@ -42,5 +42,15 @@ export const STEP_DEFINITIONS: StepDefinition[] = [
     required: false,
     icon: Bell,
     tutorialKey: "notification",
+  },
+  {
+    key: "theme",
+    title: "好みの外観を選ぶ",
+    description:
+      "ライトモード・ダークモードなど、使いやすい外観を選べます。",
+    subtitle: "ステップ4: アプリの見た目を選びましょう",
+    required: false,
+    icon: Palette,
+    tutorialKey: "theme",
   },
 ];


### PR DESCRIPTION
# 概要
オンボーディングウィザードにステップ4（テーマ選択）を追加。

# 目的
初回利用時にユーザーが好みの外観（ライト/ダーク/システム）を設定できるようにする。設定画面を探さなくても最初からダークモード等で使い始められる。

# 変更内容
- `steps-config.ts`: `StepKey`型に`"theme"`を追加、`STEP_DEFINITIONS`にステップ4を追加
- `ThemeStep.tsx`（新規）: テーマ選択コンポーネント（3つのカード選択、即座にプレビュー反映）
- `StepTutorials.tsx`: テーマ用チュートリアル説明を追加
- `use-onboarding-wizard.ts`: `stepCompletion`にtheme追加、完了判定条件を更新
- `OnboardingWizard.tsx`: ThemeStepの組み込み、テーマ名state管理
- `CompletionScreen.tsx`: サマリーに外観（テーマ名）の表示を追加

# 影響範囲
- オンボーディングウィザード（`/onboarding/welcome`）にステップ4が追加される
- 既存のステップ1〜3の動作に変更なし
- DBマイグレーション不要、環境変数の追加不要

# 関連ブランチ名
なし（フロントエンドのみの変更）

Closes #140