### PR TITLE
Fix logout not clearing next-auth session

### DIFF
--- a/src/lib/auth/logout.ts
+++ b/src/lib/auth/logout.ts
@@ -1,9 +1,9 @@
 "use server";
 
+import { signOut } from "@/auth";
 import { clearAuthCookiesAction } from "@/app/(auth)/auth-actions";
-import { redirect } from "next/navigation";
 
 export async function logout() {
   await clearAuthCookiesAction();
-  redirect("/signin");
+  await signOut({ redirectTo: "/signin" });
 }


### PR DESCRIPTION
# 概要
ログアウト時に next-auth の JWT セッションがクリアされず、LP でユーザー名が表示され続けるバグを修正

# 目的
ログアウト後の認証状態を完全にクリアし、ユーザーに正しい未認証状態を表示する

# 変更内容
- `src/lib/auth/logout.ts` で `redirect()` の代わりに next-auth の `signOut({ redirectTo })` を呼び出すように変更
- これにより `access_token` Cookie と next-auth JWT セッション Cookie の両方がクリアされる

# 影響範囲
- ログアウト処理のみ
- LP および `auth()` に依存するサーバーコンポーネントの表示が正しくなる

# 関連ブランチ名
なし（front のみの変更）

Closes #144